### PR TITLE
select the most recent api version instead of 4.1

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -417,7 +417,7 @@ module Fog
           # Negotiate the API revision
           if not revision
             rev = @connection.serviceContent.about.apiVersion
-            @connection.rev = [ rev, ENV['FOG_VSPHERE_REV'] || '4.1' ].min
+            @connection.rev = [ rev, ENV['FOG_VSPHERE_REV'] || '4.1' ].max
           end
 
           @vsphere_is_vcenter = @connection.serviceContent.about.apiType == "VirtualCenter"


### PR DESCRIPTION
This PR changes the behavior of negotiate_revision to negotiate the most recent revision instead of basically enforcing 4.1 for anything newer.