### PR TITLE
remove ruby 1.8 from travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     - rvm: jruby-head
   fast_finish: true
   include:
-    - rvm: 1.8.7
-      gemfile: gemfiles/Gemfile.1.9.2-
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.1.9.2+
     - rvm: 2.0.0
@@ -18,8 +16,6 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.2.0
       gemfile: Gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/Gemfile.1.9.2-
     - rvm: jruby-19mode
       gemfile: gemfiles/Gemfile.1.9.2+
     - rvm: jruby-head


### PR DESCRIPTION
... as tests are failing and support has been dropped.