### PR TITLE
implement storage pods

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -33,6 +33,8 @@ module Fog
       collection :networks
       model :datastore
       collection :datastores
+      model :storage_pod
+      collection :storage_pods
       model :folder
       collection :folders
       model :customvalue
@@ -63,6 +65,8 @@ module Fog
       request :get_network
       request :list_datastores
       request :get_datastore
+      request :list_storage_pods
+      request :get_storage_pod
       request :list_compute_resources
       request :get_compute_resource
       request :list_templates

--- a/lib/fog/vsphere/models/compute/datacenter.rb
+++ b/lib/fog/vsphere/models/compute/datacenter.rb
@@ -19,6 +19,10 @@ module Fog
           service.datastores({ :datacenter => path.join("/") }.merge(filters))
         end
 
+        def storage_pods filters = { }
+          service.storage_pods({ :datacenter => path.join("/") }.merge(filters))
+        end
+
         def vm_folders filters = { }
           service.folders({ :datacenter => path.join("/"), :type => :vm }.merge(filters))
         end

--- a/lib/fog/vsphere/models/compute/storage_pod.rb
+++ b/lib/fog/vsphere/models/compute/storage_pod.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Vsphere
+      class StoragePod < Fog::Model
+        identity :id
+
+        attribute :name
+        attribute :datacenter
+        attribute :type
+        attribute :freespace
+        attribute :capacity
+
+        def to_s
+          name
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/models/compute/storage_pods.rb
+++ b/lib/fog/vsphere/models/compute/storage_pods.rb
@@ -1,0 +1,22 @@
+require 'fog/core/collection'
+require 'fog/vsphere/models/compute/storage_pod'
+
+module Fog
+  module Compute
+    class Vsphere
+      class StoragePods < Fog::Collection
+        model Fog::Compute::Vsphere::StoragePod
+        attribute :datacenter
+
+        def all(filters = {})
+          load service.list_storage_pods(filters.merge(datacenter: datacenter))
+        end
+
+        def get(id)
+          requires :datacenter
+          new service.get_storage_pod(id, datacenter)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/models/compute/volume.rb
+++ b/lib/fog/vsphere/models/compute/volume.rb
@@ -6,6 +6,7 @@ module Fog
         identity :id
 
         attribute :datastore
+        attribute :storage_pod
         attribute :mode
         attribute :size
         attribute :thin

--- a/lib/fog/vsphere/requests/compute/get_storage_pod.rb
+++ b/lib/fog/vsphere/requests/compute/get_storage_pod.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def get_storage_pod(name, datacenter_name)
+          storage_pod = get_raw_storage_pod(name, datacenter_name)
+          raise(Fog::Compute::Vsphere::NotFound) unless storage_pod
+          storage_pod_attributes(storage_pod, datacenter_name)
+        end
+
+        protected
+
+        def get_raw_storage_pod(name, datacenter_name)
+          dc = find_raw_datacenter(datacenter_name)
+
+          @connection.serviceContent.viewManager.CreateContainerView({
+            :container  => dc,
+            :type       => ["StoragePod"],
+            :recursive  => true
+          }).view.select{|pod| pod.name == name}.first
+        end
+      end
+
+      class Mock
+        def get_storage_pod(name, datacenter_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/list_storage_pods.rb
+++ b/lib/fog/vsphere/requests/compute/list_storage_pods.rb
@@ -1,0 +1,41 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def list_storage_pods(filters = { })
+          datacenter_name = filters[:datacenter]
+          raw_storage_pods(datacenter_name).map do |storage_pod|
+            storage_pod_attributes(storage_pod, datacenter_name)
+          end.compact
+        end
+
+        private
+        def raw_storage_pods(datacenter_name)
+          dc = find_raw_datacenter(datacenter_name)
+
+          @connection.serviceContent.viewManager.CreateContainerView({
+            :container  => dc,
+            :type       => ["StoragePod"],
+            :recursive  => true
+          }).view
+        end
+        protected
+
+        def storage_pod_attributes storage_pod, datacenter
+          {
+            :id          => managed_obj_id(storage_pod),
+            :name        => storage_pod.name,
+            :freespace   => storage_pod.summary.freeSpace,
+            :capacity    => storage_pod.summary.capacity,
+            :datacenter  => datacenter,
+          }
+        end
+      end
+      class Mock
+        def list_storage_pods(datacenter_name)
+          []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds storage pods (datastore clusters) to fog. You can create a new vm or clone an existing one.