### PR TITLE
implement cdrom options

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -43,6 +43,8 @@ module Fog
       collection :customfields
       model :scsicontroller
       model :process
+      model :cdrom
+      collection :cdroms
 
       request_path 'fog/vsphere/requests/compute'
       request :current_time
@@ -77,11 +79,14 @@ module Fog
       request :list_vm_interfaces
       request :modify_vm_interface
       request :modify_vm_volume
+      request :modify_vm_cdrom
       request :list_vm_volumes
+      request :list_vm_cdroms
       request :get_virtual_machine
       request :vm_reconfig_hardware
       request :vm_reconfig_memory
       request :vm_reconfig_cpus
+      request :vm_reconfig_cdrom
       request :vm_config_vnc
       request :create_folder
       request :list_server_types
@@ -97,6 +102,7 @@ module Fog
       request :list_child_snapshots
       request :revert_to_snapshot
       request :list_processes
+      request :upload_iso
 
       module Shared
         attr_reader :vsphere_is_vcenter
@@ -240,6 +246,17 @@ module Fog
                       "name"    => "Network adapter 1",
                       "status"  => "ok",
                       "summary" => "VM Network",
+                     }],
+                 "cdroms" =>
+                    [{
+                      "name"                => "CD-/DVD-Drive 1",
+                      "filename"            => nil,
+                      "key"                 => 3000,
+                      "controller_key"      => 200,
+                      "unit_number"         => 0,
+                      "start_connected"     => false,
+                      "allow_guest_control" => true,
+                      "connected"           => false,
                      }],
                  "hypervisor"       => "gunab.puppetlabs.lan",
                  "guest_id"         => "rhel6_64Guest",

--- a/lib/fog/vsphere/models/compute/cdrom.rb
+++ b/lib/fog/vsphere/models/compute/cdrom.rb
@@ -1,0 +1,65 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Cdrom < Fog::Model
+        identity :key
+
+        attribute :filename
+        attribute :name, :default => "CD-/DVD-ROM Drive"
+        attribute :controller_key
+        attribute :unit_number
+        attribute :start_connected
+        attribute :allow_guest_control
+        attribute :connected
+
+        has_one_identity :server, :servers, :aliases => :instance_uuid
+
+        def to_s
+          name
+        end
+
+        def destroy
+          requires :instance_uuid, :key, :unit_number
+
+          service.destroy_vm_cdrom(self)
+          true
+        end
+
+        def save
+          requires :instance_uuid
+
+          if unit_number.nil?
+            used_unit_numbers = server.cdroms.map { |cdrom| cdrom.unit_number }
+            max_unit_number = used_unit_numbers.max
+
+            if max_unit_number > server.cdroms.size
+              # If the max ID exceeds the number of cdroms, there must be a hole in the range. Find a hole and use it.
+              self.unit_number = max_unit_number.times.to_a.find { |i| used_unit_numbers.exclude?(i) }
+            else
+              self.unit_number = max_unit_number + 1
+            end
+          else
+            if server.cdroms.any? { |cdrom| cdrom.unit_number == self.unit_number && cdrom.id != self.id }
+              raise "A cdrom already exists with that unit_number, so we can't save the new cdrom"
+            end
+          end
+
+          data = service.add_vm_cdrom(self)
+
+          if data['task_state'] == 'success'
+            # We have to query vSphere to get the cdrom attributes since the task handle doesn't include that info.
+            created = server.cdroms.get(unit_number)
+
+            self.key = created.key
+            self.filename = created.filename
+            self.unit_number = created.unit_number
+
+            true
+          else
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/models/compute/cdroms.rb
+++ b/lib/fog/vsphere/models/compute/cdroms.rb
@@ -1,0 +1,18 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Cdroms < Fog::Collection
+        attribute :instance_uuid, :alias => :server_id
+        model Fog::Compute::Vsphere::Cdrom
+
+        def all(filters = {})
+          load service.list_vm_cdroms(instance_uuid)
+        end
+
+        def get(unit_number)
+          all.find { |cdrom| cdrom.unit_number == unit_number }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -237,6 +237,14 @@ module Fog
           end
         end
 
+        def cdroms(opts = {})
+          service.cdroms(:instance_uuid => self.id).all(opts)
+        end
+
+        def cdrom(key)
+          cdroms.get(key)
+        end
+
         def guest_processes(opts = {})
           fail 'VM tools must be running' unless tools_running?
           service.list_processes(self.id, opts)

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -96,6 +96,10 @@ module Fog
             devices << create_controller(attributes[:scsi_controller]||attributes["scsi_controller"]||{})
             devices << disks.map { |disk| create_disk(disk, disks.index(disk), :add, 1000, get_storage_pod(attributes)) }
           end
+
+          if (cdroms = attributes[:cdroms])
+            devices << cdroms.map { |cdrom| create_cdrom(cdrom, cdroms.index(cdrom)) }
+          end
           devices.flatten
         end
 
@@ -259,6 +263,22 @@ module Fog
           payload
         end
 
+        def create_cdrom cdrom, index = 0, operation = :add, controller_key = 200
+          {
+            :operation     => operation,
+            :device        => RbVmomi::VIM.VirtualCdrom(
+              :key           => cdrom.key || index,
+              :backing       => RbVmomi::VIM::VirtualCdromRemoteAtapiBackingInfo(deviceName: ''),
+              :controllerKey => controller_key,
+              connectable: RbVmomi::VIM::VirtualDeviceConnectInfo(
+                startConnected: false,
+                connected: false,
+                allowGuestControl: true,
+              ),
+            )
+          }
+        end
+
         def extra_config attributes
           [
             {
@@ -271,6 +291,22 @@ module Fog
 
       class Mock
         def create_vm attributes = { }
+        end
+
+        def create_cdrom cdrom, index = 0, operation = :add, controller_key = 200
+          {
+            :operation     => operation,
+            :device        => {
+              :key           => cdrom.key || index,
+              :backing       => { deviceName: '' },
+              :controllerKey => controller_key,
+              connectable: {
+                startConnected: false,
+                connected: false,
+                allowGuestControl: true,
+              },
+            }
+          }
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_vm_cdroms.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_cdroms.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def list_vm_cdroms(vm_id)
+          get_vm_ref(vm_id).config.hardware.device.select { |hw| hw.class == RbVmomi::VIM::VirtualCdrom }.map do |cdrom|
+            {
+              :filename => (cdrom.backing.fileName rescue(nil)),
+              :name => cdrom.deviceInfo.label,
+              :key => cdrom.key,
+              :controller_key => cdrom.controllerKey,
+              :unit_number => cdrom.unitNumber,
+              :start_connected => cdrom.connectable.startConnected,
+              :allow_guest_control => cdrom.connectable.allowGuestControl,
+              :connected => cdrom.connectable.connected,
+              :instance_uuid => vm_id,
+            }
+          end
+        end
+      end
+      class Mock
+        def list_vm_cdroms(vm_id)
+          raise Fog::Compute::Vsphere::NotFound, 'VM not Found' unless self.data[:servers].key?(vm_id)
+          return [] unless self.data[:servers][vm_id].key?('cdroms')
+          self.data[:servers][vm_id]['cdroms'].map {|h| h.merge({:instance_uuid => vm_id}) }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/modify_vm_cdrom.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_cdrom.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def add_vm_cdrom(cdrom)
+          vm_reconfig_hardware('instance_uuid' => cdrom.server.instance_uuid, 'hardware_spec' => {'deviceChange'=>[create_cdrom(cdrom, cdrom.unit_number, :add)]})
+        end
+
+        def destroy_vm_cdrom(cdrom)
+          vm_reconfig_hardware('instance_uuid' => cdrom.server.instance_uuid, 'hardware_spec' => {'deviceChange'=>[create_cdrom(cdrom, cdrom.unit_number, :remove)]})
+        end
+      end
+
+      class Mock
+        def add_vm_cdrom(cdrom)
+          vm_reconfig_hardware('instance_uuid' => cdrom.server.instance_uuid, 'hardware_spec' => {'deviceChange'=>[create_cdrom(cdrom, cdrom.unit_number, :add)]})
+        end
+
+        def destroy_vm_cdrom(cdrom)
+          vm_reconfig_hardware('instance_uuid' => cdrom.server.instance_uuid, 'hardware_spec' => {'deviceChange'=>[create_cdrom(cdrom, cdrom.unit_number, :remove)]})
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
@@ -13,7 +13,7 @@ module Fog
 
       class Mock
         def add_vm_volume(volume)
-          true
+          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_cdrom(volume, volume.unit_number, :add)]})
         end
 
         def destroy_vm_volume(volume)

--- a/lib/fog/vsphere/requests/compute/upload_iso.rb
+++ b/lib/fog/vsphere/requests/compute/upload_iso.rb
@@ -1,0 +1,34 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def upload_iso_check_options(options)
+          default_options = {
+            'upload_directory' => 'isos',
+          }
+          options = default_options.merge(options)
+          required_options = %w{ datacenter datastore local_path }
+          required_options.each do |param|
+            raise ArgumentError, "#{required_options.join(', ')} are required" unless options.key? param
+          end
+          raise Fog::Compute::Vsphere::NotFound, "Datacenter #{options["datacenter"]} Doesn't Exist!" unless get_datacenter(options["datacenter"])
+          raise Fog::Compute::Vsphere::NotFound, "Datastore #{options["datastore"]} Doesn't Exist!" unless get_raw_datastore(options['datastore'], options['datacenter'])
+          options
+        end
+
+        def upload_iso(options = {})
+          options = upload_iso_check_options(options)
+          datastore = get_raw_datastore(options['datastore'], options['datacenter'])
+          datacenter = get_datacenter(options['datacenter'])
+          filename = options['filename'] || File.basename(options['local_path'])
+          unless datastore.exists? options['upload_directory']+'/'
+            @connection.serviceContent.fileManager.MakeDirectory :name => "[#{options['datastore']}] #{options['directory']}",
+                                                                 :datacenter => datacenter,
+                                                                 :createParentDirectories => false
+          end
+          datastore.upload options['upload_directory']+'/'+filename, options['local_path']
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/vm_reconfig_cdrom.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reconfig_cdrom.rb
@@ -1,0 +1,68 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def vm_reconfig_cdrom(options = {})
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.key? 'instance_uuid'
+          # Attach iso / disattach
+          if options.has_key?('iso')
+            raise ArgumentError, "datastore is a required parameter" unless options.key? 'datastore'
+            backing = RbVmomi::VIM::VirtualCdromIsoBackingInfo(
+              fileName: "[#{options['datastore']}] #{options['iso']}"
+            )
+          else
+            backing = RbVmomi::VIM::VirtualCdromRemoteAtapiBackingInfo(deviceName: '')
+          end
+          cdrom_obj = get_vm_ref(options['instance_uuid']).config.hardware.device.grep(RbVmomi::VIM::VirtualCdrom).first
+          hardware_spec = {
+            deviceChange: [{
+              operation: :edit,
+              device: RbVmomi::VIM::VirtualCdrom(
+                backing: backing,
+                key: cdrom_obj.key,
+                controllerKey: cdrom_obj.controllerKey,
+                connectable: RbVmomi::VIM::VirtualDeviceConnectInfo(
+                  startConnected: options['start_connected'] || false,
+                  connected: options['connected'] || false,
+                  allowGuestControl: options['allow_guest_control'] || true,
+                )
+              )
+            }]
+          }
+          vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
+        end
+      end
+
+      class Mock
+        def vm_reconfig_cdrom(options = {})
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.key? 'instance_uuid'
+          if options.has_key?('iso')
+            raise ArgumentError, "datastore is a required parameter" unless options.key? 'datastore'
+            backing = {
+              fileName: "[#{options['datastore']}] #{options['iso']}"
+            }
+          else
+            backing = {deviceName: ''}
+          end
+          cdrom_obj = list_vm_cdroms(options['instance_uuid']).first
+          hardware_spec = {
+            deviceChange: [{
+              operation: :edit,
+              device: {
+                backing: backing,
+                key: cdrom_obj['key'],
+                controllerKey: cdrom_obj['controllerKey'],
+                connectable: {
+                  startConnected: options['start_connected'] || false,
+                  connected: options['connected'] || false,
+                  allowGuestControl: options['allow_guest_control'] || true,
+                }
+              }
+            }]
+          }
+          vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
+        end
+      end
+    end
+  end
+end

--- a/tests/requests/compute/list_vm_cdroms_tests.rb
+++ b/tests/requests/compute/list_vm_cdroms_tests.rb
@@ -1,0 +1,10 @@
+Shindo.tests('Fog::Compute[:vsphere] | list_vm_cdroms request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  tests('The response should') do
+    response = compute.list_vm_cdroms('5032c8a5-9c5e-ba7a-3804-832a03e16381')
+    test('be a kind of Array') { response.kind_of? Array }
+    test('it should contains Hashes') { response.all? { |i| Hash === i } }
+  end
+end

--- a/tests/requests/compute/modify_vm_cdrom_tests.rb
+++ b/tests/requests/compute/modify_vm_cdrom_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests('Fog::Compute[:vsphere] | modify_vm_cdrom request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  modify_target = '5032c8a5-9c5e-ba7a-3804-832a03e16381'
+  modify_cdrom = compute.cdroms.new(
+    instance_uuid: modify_target,
+  )
+
+  tests('When adding a cdrom the response should') do
+    response = compute.add_vm_cdrom(modify_cdrom)
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.key? 'task_state' }
+  end
+
+  tests('When destroying a cdrom the response should') do
+    response = compute.destroy_vm_cdrom(modify_cdrom)
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.key? 'task_state' }
+  end
+end

--- a/tests/requests/compute/vm_reconfig_cdrom_tests.rb
+++ b/tests/requests/compute/vm_reconfig_cdrom_tests.rb
@@ -1,0 +1,15 @@
+Shindo.tests('Fog::Compute[:vsphere] | vm_reconfig_cdrom request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  reconfig_target = '5032c8a5-9c5e-ba7a-3804-832a03e16381'
+  reconfig_spec = {
+    'start_connected' => false,
+  }
+
+  tests('the response should') do
+    response = compute.vm_reconfig_cdrom('instance_uuid' => reconfig_target, 'hardware_spec' => reconfig_spec)
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.key? 'task_state' }
+  end
+end


### PR DESCRIPTION
This PR adds code to manage cdrom drives with fog-vsphere.

I could not get the upload iso function to work, not sure if it's broken in rbvmomi or my test infrastructure. The fog code should be fine, though.