### PR TITLE
Fix update_vm_interface

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -33,7 +33,8 @@ module Fog
         end
 
         def get_vm_interface(vm_id, options={})
-          if raw = get_raw_interface(vm_id, options)
+          raw = get_raw_interface(vm_id, options)
+          if raw
             raw_to_hash(raw)
           else
             nil

--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -51,7 +51,9 @@ module Fog
           else
             raise ArgumentError, "Either key or name is a required parameter. options: #{options}" unless options.key? :key or options.key? :mac or options.key? :name
             get_raw_interfaces(vm_id).find do |nic|
-              (options.key? :key and nic.key==options[:key].to_i) or (options.key? :mac and nic.macAddress==options[:mac]) or (options.key? :name and nic.deviceInfo.label==options[:name])
+              (options.key? :key and nic.key==options[:key].to_i) or
+              (options.key? :mac and nic.macAddress==options[:mac]) or
+              (options.key? :name and nic.deviceInfo.label==options[:name])
             end
           end
         end

--- a/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
@@ -22,13 +22,13 @@ module Fog
           interface = get_interface_from_options(vmid, options)
           raw_interface = get_raw_interface(vmid, key: interface.key)
           if options[:network]
-              interface.network = options[:network]
-              backing = create_nic_backing(interface, {})
-              raw_interface.backing = backing
+            interface.network = options[:network]
+            backing = create_nic_backing(interface, {})
+            raw_interface.backing = backing
           end
           spec = {
-              operation: :edit,
-              device: raw_interface
+            operation: :edit,
+            device: raw_interface
           }          
           vm_reconfig_hardware('instance_uuid' => vmid, 'hardware_spec' => {'deviceChange'=>[spec]})
         end


### PR DESCRIPTION
The previous implementation of update_vm_interface attempted to do a `ModifyVM_Task` using a new interface, freshly created with `create_interface()`.

On our environment, this caused the VM to be left with an unusable interface, with properties that I couldn't even examine without getting a 403 back from the server.

This version of update_vm_interface takes the *existing* raw interface object from the API and edits the network backing inside that object before submitting it back as a `ModifyVM_Task`.

This fixes the issue for us. Could you please take a look and decide if it belongs upstream?