### PR TITLE
Add more mocks and add folder.destroy

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -103,6 +103,7 @@ module Fog
       request :revert_to_snapshot
       request :list_processes
       request :upload_iso
+      request :folder_destroy
 
       module Shared
         attr_reader :vsphere_is_vcenter
@@ -329,7 +330,7 @@ module Fog
                  "tools_state"      => "toolsOk",
                  "name"             => "jefftest",
                  "operatingsystem"  => "Red Hat Enterprise Linux 6 (64-bit)",
-                 "path"             => "/",
+                 "path"             => "/Solutions/wibble",
                  "tools_version"    => "guestToolsUnmanaged",
                  "ipaddress"        => "192.168.100.187",
                  "uuid"             => "42329da7-e8ab-29ec-1892-d6a4a964912a",
@@ -340,6 +341,20 @@ module Fog
               },
               :datacenters => {
                 "Solutions" => {:name => "Solutions", :status => "grey", :path => ['Solutions']}
+              },
+              :folders => {
+                'wibble' => {
+                  'name' => 'wibble',
+                  'datacenter' => 'Solutions',
+                  'path' => '/Solutions/wibble',
+                  'type' => 'vm'
+                },
+                'empty' => {
+                  'name' => 'empty',
+                  'datacenter' => 'Solutions',
+                  'path' => '/Solutions/empty',
+                  'type' => 'vm'
+                }
               },
               :storage_pods =>
                 [{:id => "group-p123456",

--- a/lib/fog/vsphere/models/compute/folder.rb
+++ b/lib/fog/vsphere/models/compute/folder.rb
@@ -18,6 +18,10 @@ module Fog
         def to_s
           name
         end
+        
+        def destroy
+          service.folder_destroy(path, datacenter)
+        end
       end
     end
   end

--- a/lib/fog/vsphere/requests/compute/create_folder.rb
+++ b/lib/fog/vsphere/requests/compute/create_folder.rb
@@ -17,6 +17,16 @@ module Fog
           end
         end
       end
+      class Mock
+        def create_folder(datacenter, path, name)
+          self.data[:folders][name] = {
+            'name'       => name,
+            'datacenter' => datacenter,
+            'path'       => "#{path}/#{name}",
+            'type'       => 'vm'
+          }
+        end
+      end
     end
   end
 end

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -300,7 +300,7 @@ module Fog
             'datacenter'        => attributes[:datacenter],
             'name'              => attributes[:name],
             'interfaces'        => attributes[:interfaces].map {{
-              'mac' => Faker::Internet.mac_address
+              'mac' => 'f2:b5:46:b5:d8:d7'
             }}
           }
           self.data[:servers][id] = vm

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -291,6 +291,20 @@ module Fog
 
       class Mock
         def create_vm attributes = { }
+          id = SecureRandom.uuid
+          vm = {
+            'id'                => id,
+            'uuid'              => id,
+            'instance_uuid'     => id,
+            'mo_ref'            => "vm-#{rand 99999}",
+            'datacenter'        => attributes[:datacenter],
+            'name'              => attributes[:name],
+            'interfaces'        => attributes[:interfaces].map {{
+              'mac' => Faker::Internet.mac_address
+            }}
+          }
+          self.data[:servers][id] = vm
+          id
         end
 
         def create_cdrom cdrom, index = 0, operation = :add, controller_key = 200

--- a/lib/fog/vsphere/requests/compute/folder_destroy.rb
+++ b/lib/fog/vsphere/requests/compute/folder_destroy.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def folder_destroy(path, datacenter_name)
+          folder = get_raw_vmfolder(path, datacenter_name)
+          if folder
+            if folder.childEntity.size > 0
+              raise Fog::Vsphere::Errors::ServiceError, "Folder #{path} is not empty"
+            else
+              task = folder.Destroy_Task
+              task.wait_for_completion
+              { 'task_state' => task.info.state }
+            end
+          else
+            raise Fog::Vsphere::Errors::NotFound, "No such folder #{path}"
+          end
+        end
+      end
+      class Mock
+        def folder_destroy(path, datacenter_name)
+          vms = list_virtual_machines(folder: path, datacenter: datacenter_name)
+          if vms.length > 0
+            raise Fog::Vsphere::Errors::ServiceError, "Folder #{path} is not empty"
+          end
+          { 'task_state' => 'success' }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/folder_destroy.rb
+++ b/lib/fog/vsphere/requests/compute/folder_destroy.rb
@@ -4,17 +4,12 @@ module Fog
       class Real
         def folder_destroy(path, datacenter_name)
           folder = get_raw_vmfolder(path, datacenter_name)
-          if folder
-            if folder.childEntity.size > 0
-              raise Fog::Vsphere::Errors::ServiceError, "Folder #{path} is not empty"
-            else
-              task = folder.Destroy_Task
-              task.wait_for_completion
-              { 'task_state' => task.info.state }
-            end
-          else
-            raise Fog::Vsphere::Errors::NotFound, "No such folder #{path}"
-          end
+          raise Fog::Vsphere::Errors::NotFound, "No such folder #{path}" unless folder
+          raise Fog::Vsphere::Errors::ServiceError, "Folder #{path} is not empty" if folder.childEntity.size > 0
+          
+          task = folder.Destroy_Task
+          task.wait_for_completion
+          { 'task_state' => task.info.state }
         end
       end
       class Mock

--- a/lib/fog/vsphere/requests/compute/get_folder.rb
+++ b/lib/fog/vsphere/requests/compute/get_folder.rb
@@ -41,7 +41,7 @@ module Fog
             # VIM::Folder#inventory since that returns _all_ managed objects of
             # a certain type _and_ their properties.
             sub = last_returned_folder.find(sub_folder, RbVmomi::VIM::Folder)
-            raise ArgumentError, "Could not descend into #{sub_folder}.  Please check your path. #{path}" unless sub
+            raise Fog::Compute::Vsphere::NotFound, "Could not descend into #{sub_folder}.  Please check your path. #{path}" unless sub
             sub
           end
         end
@@ -66,7 +66,9 @@ module Fog
       end
 
       class Mock
-        def get_folder(path, filters = { })
+        def get_folder(path, datacenter_name, type = nil)
+          self.data[:folders].values.find {|f| f['datacenter'] == datacenter_name and f['path'].end_with? path} or
+            raise Fog::Compute::Vsphere::NotFound        
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_datacenters.rb
+++ b/lib/fog/vsphere/requests/compute/list_datacenters.rb
@@ -45,7 +45,7 @@ module Fog
 
       class Mock
         def list_datacenters filters = {}
-          [ {:name => "Solutions", :status => "grey"}, {:name => "Solutions2", :status => "green" }]
+          self.data[:datacenters].values
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_datastores.rb
+++ b/lib/fog/vsphere/requests/compute/list_datastores.rb
@@ -32,7 +32,8 @@ module Fog
       end
       class Mock
         def list_datastores(datacenter_name)
-          []
+          self.data[:datastores].values.select {|d| d['datacenter'] == datacenter_name[:datacenter]} or
+            raise Fog::Compute::Vsphere::NotFound
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_networks.rb
+++ b/lib/fog/vsphere/requests/compute/list_networks.rb
@@ -30,7 +30,8 @@ module Fog
       end
       class Mock
         def list_networks(datacenter_name)
-          []
+          self.data[:networks].values.select {|n| n['datacenter'] == datacenter_name[:datacenter]} or
+            raise Fog::Compute::Vsphere::NotFound
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
+++ b/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
@@ -65,13 +65,16 @@ module Fog
         end
 
         def list_virtual_machines(options = { })
-          if options['instance_uuid'].nil? and options['mo_ref'].nil?
-            self.data[:servers].values
-          elsif !options['instance_uuid'].nil?
+          if options['instance_uuid']
             server = self.data[:servers][options['instance_uuid']]
             server.nil? ? [] : [server]
-          else
+          elsif options['mo_ref']
             self.data[:servers].values.select{|vm| vm['mo_ref'] == options['mo_ref']}
+          elsif options[:folder] and options[:datacenter]
+            self.data[:servers].values.select {|vm| vm['path'] == options[:folder] && vm['datacenter'] == options[:datacenter]}
+          else
+            options.delete('datacenter') # real code iterates if this is missing
+            self.data[:servers].values.select {|vm| options.all? {|k,v| vm[k.to_s] == v.to_s }}
           end
         end
       end

--- a/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
+++ b/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
@@ -74,6 +74,7 @@ module Fog
             self.data[:servers].values.select {|vm| vm['path'] == options[:folder] && vm['datacenter'] == options[:datacenter]}
           else
             options.delete('datacenter') # real code iterates if this is missing
+            options.reject! {|k,v| v.nil? } # ignore options with nil value
             self.data[:servers].values.select {|vm| options.all? {|k,v| vm[k.to_s] == v.to_s }}
           end
         end

--- a/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
@@ -53,6 +53,13 @@ module Fog
           raise ArgumentError, "interface is a required parameter" unless options and options[:interface]
           true
         end
+        
+        def update_vm_interface(vmid, options = {})
+          if options[:interface]
+            options[:interface].network = options[:network]
+            options[:interface].type    = options[:type]
+          end
+        end
       end
     end
   end

--- a/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
@@ -55,10 +55,9 @@ module Fog
         end
         
         def update_vm_interface(vmid, options = {})
-          if options[:interface]
-            options[:interface].network = options[:network]
-            options[:interface].type    = options[:type]
-          end
+          return unless options[:interface]
+          options[:interface].network = options[:network]
+          options[:interface].type    = options[:type]
         end
       end
     end

--- a/tests/models/compute/servers_tests.rb
+++ b/tests/models/compute/servers_tests.rb
@@ -7,7 +7,7 @@ Shindo.tests('Fog::Compute[:vsphere] | servers collection', ['vsphere']) do
     test('should be a kind of Fog::Compute::Vsphere::Servers') { servers.kind_of? Fog::Compute::Vsphere::Servers }
     tests('should be able to reload itself').succeeds { servers.reload }
     tests('should be able to get a model') do
-      tests('by managed object reference').succeeds { servers.get 'vm-715' }
+      tests('by managed object reference').succeeds { servers.get 'jefftest' }
       tests('by instance uuid').succeeds { servers.get '5032c8a5-9c5e-ba7a-3804-832a03e16381' }
     end
   end

--- a/tests/requests/compute/folder_destroy_tests.rb
+++ b/tests/requests/compute/folder_destroy_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests('Fog::Compute[:vsphere] | folder_destroy request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  empty_folder = "/Solutions/empty"
+  full_folder  = "/Solutions/wibble"
+  datacenter   = "Solutions"
+
+  tests('The response should') do
+    response = compute.folder_destroy(empty_folder, datacenter)
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.key? 'task_state' }
+  end
+  
+  tests('When folder is not empty') do
+    raises(Fog::Vsphere::Errors::ServiceError, 'raises ServiceError') do
+      compute.folder_destroy(full_folder, datacenter)
+    end
+  end
+
+end


### PR DESCRIPTION
Sorry this pull request is in two parts - unfortunately one depends on the other (although this can be rectified if required).

1. Adds/expands some more of the mocks (`create_folder`, `get_folder`, `list_datacenters`, `list_datastores`, `list_networks`, and several additions to `list_virtual_machines`). This doesn't break any of the tests except one that was using `servers.get` with a VM ID instead of a name - something that isn't supported by the real `servers.get`. We use these new mocks in our own tests but if you'd like them not to be merged upstream I can pull out the other part of this pull request separately.

2. Adds a `#destroy` to folder models and the associated `folder_destroy` request along with its mocks and a shindo test for it.