### PR TITLE
Additional create_vm options

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -135,6 +135,7 @@ module Fog
           :cpuHotAddEnabled => 'config.cpuHotAddEnabled',
           :memoryHotAddEnabled => 'config.memoryHotAddEnabled',
           :firmware => 'config.firmware',
+          :annotation => 'config.annotation',
         }
 
         def convert_vm_view_to_attr_hash(vms)

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -49,6 +49,7 @@ module Fog
         attribute :cpuHotAddEnabled
         attribute :memoryHotAddEnabled
         attribute :firmware
+        attribute :annotation
 
         def initialize(attributes={} )
           super defaults.merge(attributes)

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -103,10 +103,18 @@ module Fog
         def boot_options attributes
           # NOTE: you must be using vsphere_rev 5.0 or greater to set boot_order
           # e.g. Fog::Compute.new(provider: "vsphere", vsphere_rev: "5.5", etc)
-          return unless @vsphere_rev.to_f >= 5
-          RbVmomi::VIM::VirtualMachineBootOptions.new(
-            :bootOrder => boot_order(attributes)
-          )
+          options = {}
+          if @vsphere_rev.to_f >= 5
+            options[:bootOrder] = boot_order(attributes)
+          end
+          
+          # Set attributes[:boot_retry] to a delay in miliseconds to enable boot retries
+          if attributes[:boot_retry]
+            options[:bootRetryEnabled] = true
+            options[:bootRetryDelay]   = attributes[:boot_retry]
+          end
+                   
+          options.empty? ? nil : RbVmomi::VIM::VirtualMachineBootOptions.new(options)
         end
 
         def boot_order attributes

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -7,6 +7,7 @@ module Fog
 
           vm_cfg        = {
             :name         => attributes[:name],
+            :annotation   => attributes[:annotation],
             :guestId      => attributes[:guest_id],
             :version      => attributes[:hardware_version],
             :files        => { :vmPathName => vm_path_name(attributes) },
@@ -260,12 +261,8 @@ module Fog
         end
 
         def extra_config attributes
-          [
-            {
-              :key   => 'bios.bootOrder',
-              :value => 'ethernet0'
-            }
-          ]
+          extra_config = attributes[:extra_config] || {'bios.bootOrder' => 'ethernet0'}
+          extra_config.map {|k,v| {:key => k, :value => v.to_s} }
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -20,7 +20,7 @@ module Fog
           vm_cfg[:cpuHotAddEnabled] = attributes[:cpuHotAddEnabled] if attributes.key?(:cpuHotAddEnabled)
           vm_cfg[:memoryHotAddEnabled] = attributes[:memoryHotAddEnabled] if attributes.key?(:memoryHotAddEnabled)
           vm_cfg[:firmware] = attributes[:firmware] if attributes.key?(:firmware)
-          vm_cfg[:bootOptions] = boot_options(attributes) if attributes.key?(:boot_order)
+          vm_cfg[:bootOptions] = boot_options(attributes) if attributes.key?(:boot_order) || attributes.key?(:boot_retry)
           resource_pool = if attributes[:resource_pool]
                             get_raw_resource_pool(attributes[:resource_pool], attributes[:cluster], attributes[:datacenter])
                           else
@@ -104,10 +104,10 @@ module Fog
           # NOTE: you must be using vsphere_rev 5.0 or greater to set boot_order
           # e.g. Fog::Compute.new(provider: "vsphere", vsphere_rev: "5.5", etc)
           options = {}
-          if @vsphere_rev.to_f >= 5
+          if @vsphere_rev.to_f >= 5 and attributes[:boot_order]
             options[:bootOrder] = boot_order(attributes)
           end
-          
+
           # Set attributes[:boot_retry] to a delay in miliseconds to enable boot retries
           if attributes[:boot_retry]
             options[:bootRetryEnabled] = true


### PR DESCRIPTION
This pull request adds the following options to the `create_vm` request:

1. `:annotation`: Allows setting of the notes field on a VM during creation.
2. `:boot_retry`: Set to a number of *ms*, will set the boot option to retry failed boots after that number of *ms*.
3. `:extra_config`: Allows passing of a hash to use as `extra_config` instead of the default one with `bios.bootOrder`.