### PR TITLE
Add support for DRS Rules

### DIFF
--- a/lib/fog/vsphere/models/compute/cluster.rb
+++ b/lib/fog/vsphere/models/compute/cluster.rb
@@ -18,6 +18,10 @@ module Fog
                                                                                           :datacenter => datacenter
                                                                                         }.merge(filters))
         end
+        
+        def rules
+          service.rules(:datacenter => datacenter, :cluster => name)
+        end
 
         def to_s
           name

--- a/lib/fog/vsphere/models/compute/rule.rb
+++ b/lib/fog/vsphere/models/compute/rule.rb
@@ -1,0 +1,46 @@
+module Fog
+  module Compute
+    class Vsphere
+      # ClusterRuleInfo
+      class Rule < Fog::Model
+        identity :key
+        
+        attribute :datacenter
+        attribute :cluster
+        attribute :name
+        attribute :enabled
+        # Type should be a class - either
+        #  - RbVmomi::VIM::ClusterAntiAffinityRuleSpec
+        #  - RbVmomi::VIM::ClusterAffinityRuleSpec
+        attribute :type
+        attribute :vm_ids
+        
+        def vms
+          vm_ids.map {|id| service.servers.get(id, datacenter) }
+        end
+        
+        def vms=(vms)
+          self.vm_ids = vms.map(&:instance_uuid)
+        end
+        
+        def save
+          requires :datacenter, :cluster, :name, :enabled, :type, :vm_ids
+          if vm_ids.length < 2
+            raise ArgumentError, "A rule must have at least 2 VMs"
+          end
+          if persisted?
+            raise "Update is not supported yet"
+          else
+            self.key = service.create_rule(attributes)
+          end
+          reload
+        end
+        
+        def destroy
+          service.destroy_rule(attributes)
+        end
+        
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/models/compute/rules.rb
+++ b/lib/fog/vsphere/models/compute/rules.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Rules < Fog::Collection
+        autoload :Rule, File.expand_path('../rule', __FILE__)
+        
+        model Fog::Compute::Vsphere::Rule
+        attribute :datacenter
+        attribute :cluster
+        
+        def all(filters = {})
+          requires :datacenter, :cluster
+          load service.list_rules(:datacenter => datacenter, :cluster => cluster)
+        end
+        
+        def get(key_or_name)
+          all.find {|rule| [rule.key, rule.name].include? key_or_name } or
+            raise Fog::Compute::Vsphere::NotFound, "no such rule #{key_or_name}"
+        end
+        
+        # Pass datacenter/cluster to every new rule
+        def new(attributes={})
+          requires :datacenter, :cluster
+          super(attributes.merge(datacenter: datacenter, cluster: cluster))
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/create_rule.rb
+++ b/lib/fog/vsphere/requests/compute/create_rule.rb
@@ -1,0 +1,46 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def create_rule(attributes={})
+          cluster = get_raw_cluster(attributes[:cluster], attributes[:datacenter])
+          # Check if it already exists and blow up if it does
+          # (otherwise ESX just happily accepts it and then considers it a conflict)
+          rule = cluster.configurationEx.rule.find {|n| n[:name] == attributes[:name]}
+          if rule
+            raise ArgumentError, "Rule #{attributes[:name]} already exists!"
+          end
+          # First, create the rulespec
+          vms = attributes[:vm_ids].to_a.map {|id| get_vm_ref(id, attributes[:datacenter])}
+          spec = attributes[:type].new(
+            name: attributes[:name],
+            enabled: attributes[:enabled],
+            vm: vms
+          )
+          # Now, attach it to the cluster
+          cluster_spec = RbVmomi::VIM.ClusterConfigSpecEx(rulesSpec: [
+            RbVmomi::VIM.ClusterRuleSpec(
+              operation: RbVmomi::VIM.ArrayUpdateOperation('add'),
+              info: spec
+            )
+          ])
+          ret = cluster.ReconfigureComputeResource_Task(spec: cluster_spec, modify: true).wait_for_completion
+          rule = cluster.configurationEx.rule.find {|n| n[:name] == attributes[:name]}
+          if rule
+            return rule[:key]
+          else
+            raise Fog::Vsphere::Errors::ServiceError, "Unknown error creating rule #{attributes[:name]}"
+          end
+        end
+        
+      end
+      class Mock
+        def create_rule(attributes={})
+          attributes[:key] = rand(9999)
+          self.data[:rules][attributes[:name]] = attributes
+          attributes[:key]
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/destroy_rule.rb
+++ b/lib/fog/vsphere/requests/compute/destroy_rule.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def destroy_rule(attributes = {})
+          cluster = get_raw_cluster(attributes[:cluster], attributes[:datacenter])
+          rule    = cluster.configurationEx.rule.find {|rule| rule.key == attributes[:key]}
+          raise Fog::Vsphere::Error::NotFound, "rule #{attributes[:key]} not found" unless rule
+          delete_spec = RbVmomi::VIM.ClusterConfigSpecEx(rulesSpec: [
+            RbVmomi::VIM.ClusterRuleSpec(
+              operation: RbVmomi::VIM.ArrayUpdateOperation('remove'),
+              removeKey: rule.key
+            )
+          ])
+          cluster.ReconfigureComputeResource_Task(spec: delete_spec, modify: true).wait_for_completion
+        end
+      end
+      class Mock
+        def destroy_rule(attributes = {})
+          rule = self.data[:rules][attributes[:name]]
+          raise Fog::Vsphere::Error::NotFound unless rule
+          self.data[:rules].delete(attributes[:name])
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/get_cluster.rb
+++ b/lib/fog/vsphere/requests/compute/get_cluster.rb
@@ -17,7 +17,9 @@ module Fog
       end
 
       class Mock
-        def get_cluster(id)
+        def get_cluster(name, datacenter_name)
+          self.data[:clusters].find {|c| c[:name] == name && c[:datacenter] == datacenter_name} or
+            raise Fog::Compute::Vsphere::NotFound
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_rules.rb
+++ b/lib/fog/vsphere/requests/compute/list_rules.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def list_rules(filters = {})
+          cluster = get_raw_cluster(filters[:cluster], filters[:datacenter])
+          cluster.configurationEx.rule.map {|r| rule_attributes r, filters}
+        end
+
+        protected
+      
+        def rule_attributes(rule, filters)
+          {
+            datacenter: filters[:datacenter],
+            cluster:    filters[:cluster],
+            key:        rule[:key],
+            name:       rule[:name],
+            enabled:    rule[:enabled],
+            type:       rule.class,
+            vm_ids:     rule[:vm].map {|vm| vm.config.instanceUuid }
+          }
+        end
+      end
+      class Mock
+        def list_rules(filters = {})
+          self.data[:rules].values.select {|r| r[:datacenter] == filters[:datacenter] && r[:cluster] == filters[:cluster]}
+        end
+      end
+    end
+  end
+end

--- a/tests/models/compute/rules_tests.rb
+++ b/tests/models/compute/rules_tests.rb
@@ -1,0 +1,34 @@
+Shindo.tests('Fog::Compute[:vsphere] | rules collection', ['vsphere']) do
+  
+  compute = Fog::Compute[:vsphere]
+  cluster = compute.datacenters.first.clusters.get('Solutionscluster')
+  servers = compute.servers
+  rules = cluster.rules
+  
+  tests('The rules collection') do
+    test('should not be empty') { not rules.empty? }
+    test('should be a kind of Fog::Compute::Vsphere::Rules') { rules.kind_of? Fog::Compute::Vsphere::Rules }
+    test('should get rules') { rules.get('anti-affinity-foo').key == 4242 }
+    test('should destroy rules') { rules.first.destroy; rules.reload; rules.empty? }
+    test('should create rules') do
+      r = rules.new({
+        name: 'affinity-foo',
+        enabled: true,
+        type: RbVmomi::VIM::ClusterAffinityRuleSpec
+      })
+      r.vms = [servers.get('5032c8a5-9c5e-ba7a-3804-832a03e16381'), servers.get('502916a3-b42e-17c7-43ce-b3206e9524dc')]
+      r.save
+      rules.reload
+      rules.get('affinity-foo').key > 0
+    end
+    raises(ArgumentError, 'should not create rules with <2 vms') do
+      rules.create({
+        name: 'affinity-foo',
+        enabled: true,
+        type: RbVmomi::VIM::ClusterAffinityRuleSpec,
+        vm_ids: ['5032c8a5-9c5e-ba7a-3804-832a03e16381']
+      })
+    end
+  end
+  
+end


### PR DESCRIPTION
This pull request adds support for DRS (affinity/anti-affinity) rules on a cluster. It adds:

* `cluster.rules`
* `cluster.rules.get`
* `cluster.rules.create` (or `new` &rarr; `vms=` &rarr; `save`)
* `rule.vms`
* `rule.destroy`

It's probably slightly controversial because it moves the `@connection` object into a shadow class to work around a longstanding bug in RbVmomi with respect to passing integers to the `xsd:any` type. (VMware expects an `xsd:int` but for some reason RbVmomi sends an `xsd:long`).

If you absolutely don't want the shadow class, I can take this code out, but I'll have to strip out the whole `destroy` functionality as this currently depends on passing the integer key to an `xsd:any`.

Let me know what you think!

