### PR TITLE
Pass folder information to more VM operations

### DIFF
--- a/lib/fog/vsphere/models/compute/folder.rb
+++ b/lib/fog/vsphere/models/compute/folder.rb
@@ -10,9 +10,10 @@ module Fog
         attribute :path
         attribute :type
 
-        def vms
+        # Pass :recursive => true to get a Servers object that searches for VM names recursively
+        def vms(options = {})
           return [] if type.to_s != 'vm'
-          service.servers(:folder => path, :datacenter => datacenter)
+          service.servers(:folder => path, :datacenter => datacenter, :recursive => options[:recursive])
         end
 
         def to_s

--- a/lib/fog/vsphere/models/compute/servers.rb
+++ b/lib/fog/vsphere/models/compute/servers.rb
@@ -32,6 +32,17 @@ module Fog
         rescue Fog::Compute::Vsphere::NotFound
           nil
         end
+        
+        # Pass attributes we know about down to any VM we're creating
+        def new(attributes = {})
+          super({
+            :datacenter    => datacenter,
+            :path          => folder,
+            :cluster       => cluster,
+            :resource_pool => resource_pool,
+          }.merge(attributes))
+        end
+        
       end
     end
   end

--- a/lib/fog/vsphere/models/compute/servers.rb
+++ b/lib/fog/vsphere/models/compute/servers.rb
@@ -10,6 +10,7 @@ module Fog
         attr_accessor :cluster
         attr_accessor :resource_pool
         attr_accessor :folder
+        attr_accessor :recursive
 
         # 'folder' => '/Datacenters/vm/Jeff/Templates' will be MUCH faster.
         # than simply listing everything.
@@ -19,14 +20,15 @@ module Fog
             :cluster       => cluster,
             :network       => network,
             :resource_pool => resource_pool,
-            :folder        => folder
+            :folder        => folder,
+            :recursive     => recursive,
           }.merge(filters)
 
           load service.list_virtual_machines(f)
         end
 
         def get(id, datacenter = nil)
-          new service.get_virtual_machine id, datacenter
+          new service.get_virtual_machine id, datacenter, folder, recursive
         rescue Fog::Compute::Vsphere::NotFound
           nil
         end

--- a/lib/fog/vsphere/requests/compute/get_folder.rb
+++ b/lib/fog/vsphere/requests/compute/get_folder.rb
@@ -53,8 +53,12 @@ module Fog
             :parent     => folder.parent.name,
             :datacenter => datacenter_name,
             :type       => folder_type(folder),
-            :path       => "/"+folder.path.map(&:last).join('/'),
+            :path       => folder_path(folder),
           }
+        end
+        
+        def folder_path(folder)
+            "/"+folder.path.map(&:last).join('/')
         end
 
         def folder_type(folder)

--- a/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
+++ b/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
@@ -30,6 +30,8 @@ module Fog
 
         def get_vm_by_name(name, dc, folder, recursive)
           if folder
+            # This returns an Enumerator, which when called with .find will
+            # search only until it finds the VM we're looking for
             vms = raw_list_all_virtual_machines_in_folder(folder, dc, recursive)
           else
             vms = raw_list_all_virtual_machines(dc)
@@ -38,11 +40,11 @@ module Fog
           if name.include?('/')
             folder = File.dirname(name)
             basename = File.basename(name)
-            vms.keep_if { |v| v["name"] == basename && v.parent.pretty_path.include?(folder) }.first
+            vms.find { |v| v["name"] == basename && v.parent.pretty_path.include?(folder) }
           else
-            vms.keep_if { |v| v["name"] == name }.first
+            vms.find { |v| v["name"] == name }
           end
-        end
+        end        
         
       end
 

--- a/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
+++ b/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
@@ -2,14 +2,14 @@ module Fog
   module Compute
     class Vsphere
       class Real
-        def get_virtual_machine(id, datacenter_name = nil)
+        def get_virtual_machine(id, datacenter_name = nil, folder = nil, recursive = false)
           # The larger the VM list the longer it will take if not searching based on UUID.
-          convert_vm_mob_ref_to_attr_hash(get_vm_ref(id, datacenter_name))
+          convert_vm_mob_ref_to_attr_hash(get_vm_ref(id, datacenter_name, folder, recursive))
         end
 
         protected
 
-        def get_vm_ref(id, dc = nil)
+        def get_vm_ref(id, dc = nil, folder = nil, recursive = false)
           raw_datacenter = find_raw_datacenter(dc) if dc
           vm = case is_uuid?(id)
                  # UUID based
@@ -20,18 +20,22 @@ module Fog
                  else
                    # try to find based on VM name
                    if dc
-                     get_vm_by_name(id, dc)
+                     get_vm_by_name(id, dc, folder, recursive)
                    else
-                     raw_datacenters.map { |d| get_vm_by_name(id, d["name"])}.compact.first
+                     raw_datacenters.map { |d| get_vm_by_name(id, d["name"], folder, recursive)}.compact.first
                    end
                end
           vm ? vm : raise(Fog::Compute::Vsphere::NotFound, "#{id} was not found")
         end
 
-        def get_vm_by_name(name, dc)
-          vms = raw_list_all_virtual_machines(dc)
+        def get_vm_by_name(name, dc, folder, recursive)
+          if folder
+            vms = raw_list_all_virtual_machines_in_folder(folder, dc, recursive)
+          else
+            vms = raw_list_all_virtual_machines(dc)
+          end
 
-         if name.include?('/')
+          if name.include?('/')
             folder = File.dirname(name)
             basename = File.basename(name)
             vms.keep_if { |v| v["name"] == basename && v.parent.pretty_path.include?(folder) }.first
@@ -39,10 +43,11 @@ module Fog
             vms.keep_if { |v| v["name"] == name }.first
           end
         end
+        
       end
 
       class Mock
-        def get_virtual_machine(id, datacenter_name = nil)
+        def get_virtual_machine(id, datacenter_name = nil, folder = nil, recursive = false)
           if is_uuid?(id)
             vm = list_virtual_machines({ 'instance_uuid' => id, 'datacenter' => datacenter_name }).first
           else


### PR DESCRIPTION
Prior to this pull request, if you call `#vms` on a folder, the folder information is lost. This means:

* If you do `folder.vms.get(name)` it will actually fetch *every* VM in the datacenter and return a VM by that name wherever it lives, whether it's in the folder or not. This is both (incredibly) slow and leaky.
* If you do `folder.vms.create(hash)` you need to include datacenter and folder information in the hash even though they're already known by `folder`.

This pull request addresses these issues by changing this behaviour:

* `folder.vms.get(name)` will only return the VM if it is in the specified folder itself.
* `folder.vms(recursive: true).get(name)` will return the VM if it is in the specified folder or any of its children.
* `vms.create(hash)` will include datacenter/folder/cluster/resource_pool from the vms object if they are known (datacenter and folder are known in the case of `folder.vms` as a side-effect of the above).

The recursive search uses an `Enumerator` and `#find` to ensure we stop digging recursively once we've found the VM we're looking for, which provides a nice extra performance boost if your VM has a name that's early in the alphabet. :smile: 