### PR TITLE
Fix Fog::Mock.reset properly

### DIFF
--- a/lib/fog/vsphere.rb
+++ b/lib/fog/vsphere.rb
@@ -1,7 +1,10 @@
 require 'fog/core'
-require 'fog/vsphere/compute'
 
 module Fog
+  module Compute
+    autoload :Vsphere, File.expand_path('../vsphere/compute.rb', __FILE__)
+  end
+
   module Vsphere
     extend Fog::Provider
 


### PR DESCRIPTION
- Remove the require of 'fog/vsphere/compute'
- Add module Compute and autoload Vsphere (previous autoload was reversed)