### PR TITLE
Fix cannot create vm on "Resources" resource pool

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -21,7 +21,7 @@ module Fog
           vm_cfg[:memoryHotAddEnabled] = attributes[:memoryHotAddEnabled] if attributes.key?(:memoryHotAddEnabled)
           vm_cfg[:firmware] = attributes[:firmware] if attributes.key?(:firmware)
           vm_cfg[:bootOptions] = boot_options(attributes) if attributes.key?(:boot_order) || attributes.key?(:boot_retry)
-          resource_pool = if attributes[:resource_pool]
+          resource_pool = if attributes[:resource_pool] && attributes[:resource_pool] != 'Resources'
                             get_raw_resource_pool(attributes[:resource_pool], attributes[:cluster], attributes[:datacenter])
                           else
                             get_raw_cluster(attributes[:cluster], attributes[:datacenter]).resourcePool

--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -108,7 +108,7 @@ module Fog
 
           # Options['resource_pool']<~Array>
           # Now find _a_ resource pool to use for the clone if one is not specified
-          if ( options.key?('resource_pool') && options['resource_pool'].is_a?(Array) && options['resource_pool'].length == 2 )
+          if ( options.key?('resource_pool') && options['resource_pool'].is_a?(Array) && options['resource_pool'].length == 2 && options['resource_pool'][1] != 'Resources')
             cluster_name = options['resource_pool'][0]
             pool_name = options['resource_pool'][1]
             resource_pool = get_raw_resource_pool(pool_name, cluster_name, options['datacenter'])


### PR DESCRIPTION
When querying the vsphere api for resource pools, it returns the pool
"Resources" which basically means "no pool". When creating a vm on that
pool, the creation fails. This commit fixes this behavior by creating
the vm on the cluster object.