### PR TITLE
storage pods: fix wrong string assignment

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -245,7 +245,7 @@ module Fog
           end
           # If we deploy the vm on a storage pod, datastore has to be an empty string
           if storage_pod
-            datastore ''
+            datastore = ''
           else
             datastore = "[#{disk.datastore}]"
           end


### PR DESCRIPTION
I found a small, but very annoying bug in the storage pod code. Here is the fix.