### PR TITLE
improve upload_iso

### DIFF
--- a/lib/fog/vsphere/requests/compute/upload_iso.rb
+++ b/lib/fog/vsphere/requests/compute/upload_iso.rb
@@ -19,14 +19,15 @@ module Fog
         def upload_iso(options = {})
           options = upload_iso_check_options(options)
           datastore = get_raw_datastore(options['datastore'], options['datacenter'])
-          datacenter = get_datacenter(options['datacenter'])
+          datacenter = get_raw_datacenter(options['datacenter'])
           filename = options['filename'] || File.basename(options['local_path'])
           unless datastore.exists? options['upload_directory']+'/'
-            @connection.serviceContent.fileManager.MakeDirectory :name => "[#{options['datastore']}] #{options['directory']}",
+            @connection.serviceContent.fileManager.MakeDirectory :name => "[#{options['datastore']}] #{options['upload_directory']}",
                                                                  :datacenter => datacenter,
                                                                  :createParentDirectories => false
           end
           datastore.upload options['upload_directory']+'/'+filename, options['local_path']
+          datastore.exists? options['upload_directory']+'/'+filename
         end
       end
     end


### PR DESCRIPTION
This PR fixes some issues with upload_iso.

* datastore.upload does not give a proper return code, so we check if the uploaded file actually exists on the datastore
* the create directory command expects a raw datacenter, not a fog datacenter object
* it should create the upload_directory on the datastore