### PR TITLE
Allow extraConfig options when cloning VMs.

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -162,6 +162,7 @@ module Fog
           virtual_machine_config_spec.cpuHotAddEnabled = options['cpuHotAddEnabled'] if ( options.key?('cpuHotAddEnabled') )
           virtual_machine_config_spec.memoryHotAddEnabled = options['memoryHotAddEnabled'] if ( options.key?('memoryHotAddEnabled') )
           virtual_machine_config_spec.firmware = options['firmware'] if ( options.key?('firmware') )
+          virtual_machine_config_spec.extraConfig = extra_config(extra_config: options['extraConfig']) if ( options.key?('extraConfig') )
           # Options['customization_spec']
           # OLD Options still supported
           # * domain <~String> - *REQUIRED* - Sets the server's domain for customization


### PR DESCRIPTION
Found myself needing this to [configure CoreOS VMs](https://coreos.com/os/docs/latest/booting-on-vmware.html) automatically.  Let me know if there's anything I should improve with tests / docs / refactoring (the `extra_config` formatting function comes from create_vm.rb).