### PR TITLE
Don't destroy stacktrace when things go wrong

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_folder.rb
+++ b/lib/fog/vsphere/requests/compute/create_folder.rb
@@ -13,7 +13,7 @@ module Fog
             # new path will be path/name, example: "Production/Pool1"
             new_folder.path.reject { |a| a.first.class == "Folder" }.map { |a| a.first.name }.join("/").sub(/^\/?Datacenters\/#{datacenter}\/vm\/?/, '')
           rescue => e
-            raise e, "failed to create folder: #{e}"
+            raise e, "failed to create folder: #{e}", e.backtrace
           end
         end
       end

--- a/lib/fog/vsphere/requests/compute/create_folder.rb
+++ b/lib/fog/vsphere/requests/compute/create_folder.rb
@@ -12,8 +12,6 @@ module Fog
             # output is cleaned up to return the new path
             # new path will be path/name, example: "Production/Pool1"
             new_folder.path.reject { |a| a.first.class == "Folder" }.map { |a| a.first.name }.join("/").sub(/^\/?Datacenters\/#{datacenter}\/vm\/?/, '')
-          rescue => e
-            raise e, "failed to create folder: #{e}", e.backtrace
           end
         end
       end

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -41,7 +41,7 @@ module Fog
           end
           vm.config.instanceUuid
         rescue => e
-          raise e, "failed to create vm: #{e}"
+          raise e, "failed to create vm: #{e}", e.backtrace
         end
 
         private

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -40,8 +40,6 @@ module Fog
             vm = create_vm_on_datastore(vm_cfg, vmFolder, resource_pool, host)
           end
           vm.config.instanceUuid
-        rescue => e
-          raise e, "failed to create vm: #{e}", e.backtrace
         end
 
         private


### PR DESCRIPTION
Currently, if anything gets caught by either of these handlers then the re-raised exception will be lacking the original stacktrace, which makes debugging the underlying cause impossible.

Example trace;
```
failed to create vm: NoPermission: Permission to perform this operation was denied.
   
RbVmomi::Fault: failed to create vm: NoPermission: Permission to perform this operation was denied.
  /usr/lib/ruby/gems/2.1.0/gems/fog-vsphere-1.0.0/lib/fog/vsphere/requests/compute/create_vm.rb:44:in `rescue in create_vm'
  /usr/lib/ruby/gems/2.1.0/gems/fog-vsphere-1.0.0/lib/fog/vsphere/requests/compute/create_vm.rb:8:in `create_vm'
  /usr/lib/ruby/gems/2.1.0/gems/fog-vsphere-1.0.0/lib/fog/vsphere/models/compute/server.rb:273:in `save'
  /usr/share/foreman/app/models/compute_resources/foreman/model/vmware.rb:364:in `create_vm'
  /usr/share/foreman/app/models/concerns/orchestration/compute.rb:82:in `setCompute'
  /usr/share/foreman/app/models/concerns/orchestration.rb:162:in `execute'
  /usr/share/foreman/app/models/concerns/orchestration.rb:107:in `block in process'
  /usr/share/foreman/app/models/concerns/orchestration.rb:99:in `each'
  /usr/share/foreman/app/models/concerns/orchestration.rb:99:in `process'
  /usr/share/foreman/app/models/concerns/orchestration.rb:35:in `on_save'
...
```

As can be seen, the trace ends on the rescue block where it's repackaged and re-raised.

This PR solves the issue by passing along the original exception backtrace into the repackaged exception object.