### PR TITLE
Update fog-vsphere.gemspec

### DIFF
--- a/fog-vsphere.gemspec
+++ b/fog-vsphere.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.8.7'
 
   spec.add_runtime_dependency 'fog-core'
-  spec.add_runtime_dependency 'rbvmomi', '~> 1.8'
+  spec.add_runtime_dependency 'rbvmomi', '~> 1.8.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
Lock to the 1.8 version since 1.9 breaks on older Ruby