### PR TITLE
Adding new functionality for creating, listing and destroying DRS groups

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -112,6 +112,10 @@ module Fog
       request :list_rules
       request :destroy_rule
       request :list_hosts
+      request :create_group
+      request :list_groups
+      request :destroy_group
+      request :get_host
 
       module Shared
         attr_reader :vsphere_is_vcenter

--- a/lib/fog/vsphere/requests/compute/create_group.rb
+++ b/lib/fog/vsphere/requests/compute/create_group.rb
@@ -15,7 +15,7 @@ module Fog
                   info: spec
               )
           ])
-          ret = cluster.ReconfigureComputeResource_Task(spec: cluster_spec, modify: true).wait_for_completion
+          cluster.ReconfigureComputeResource_Task(spec: cluster_spec, modify: true).wait_for_completion
           group = cluster.configurationEx.group.find {|n| n[:name] == attributes[:name]}
           if group
             return group[:name]

--- a/lib/fog/vsphere/requests/compute/create_group.rb
+++ b/lib/fog/vsphere/requests/compute/create_group.rb
@@ -1,0 +1,52 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def create_group(attributes={})
+          cluster = get_raw_cluster(attributes[:cluster], attributes[:datacenter])
+          group = cluster.configurationEx.group.find {|n| n[:name] == attributes[:name]}
+          if group
+            raise ArgumentError, "Group #{attributes[:name]} already exists!"
+          end
+          spec = get_spec attributes
+          cluster_spec = RbVmomi::VIM.ClusterConfigSpecEx(groupSpec: [
+              RbVmomi::VIM.ClusterGroupSpec(
+                  operation: RbVmomi::VIM.ArrayUpdateOperation('add'),
+                  info: spec
+              )
+          ])
+          ret = cluster.ReconfigureComputeResource_Task(spec: cluster_spec, modify: true).wait_for_completion
+          group = cluster.configurationEx.group.find {|n| n[:name] == attributes[:name]}
+          if group
+            return group[:name]
+          else
+            raise Fog::Vsphere::Errors::ServiceError, "Unknown error creating group #{attributes[:name]}"
+          end
+        end
+
+        private
+
+        def get_spec(attributes={})
+          if attributes[:type].to_s == 'ClusterVmGroup'
+            vms = attributes[:vm_ids].to_a.map {|id| get_vm_ref(id, attributes[:datacenter])}
+            attributes[:type].new(
+                name: attributes[:name],
+                vm: vms
+            )
+          elsif attributes[:type].to_s == 'ClusterHostGroup'
+            attributes[:type].new(
+                name: attributes[:name],
+                host: attributes[:host_refs]
+            )
+          end
+        end
+      end
+
+      class Mock
+        def create_group(attributes={})
+          self.data[:groups][attributes[:name]] = attributes
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/destroy_group.rb
+++ b/lib/fog/vsphere/requests/compute/destroy_group.rb
@@ -4,7 +4,7 @@ module Fog
       class Real
         def destroy_group(attributes = {})
           cluster = get_raw_cluster(attributes[:cluster], attributes[:datacenter])
-          group   = cluster.configurationEx.group.find {|group| group.name == attributes[:name]}
+          group   = cluster.configurationEx.group.find {|g| g.name == attributes[:name]}
           raise Fog::Vsphere::Error::NotFound, "group #{attributes[:name]} not found" unless group
           delete_spec = RbVmomi::VIM.ClusterConfigSpecEx(groupSpec: [
             RbVmomi::VIM.ClusterGroupSpec(

--- a/lib/fog/vsphere/requests/compute/destroy_group.rb
+++ b/lib/fog/vsphere/requests/compute/destroy_group.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def destroy_group(attributes = {})
+          cluster = get_raw_cluster(attributes[:cluster], attributes[:datacenter])
+          group   = cluster.configurationEx.group.find {|group| group.name == attributes[:name]}
+          raise Fog::Vsphere::Error::NotFound, "group #{attributes[:name]} not found" unless group
+          delete_spec = RbVmomi::VIM.ClusterConfigSpecEx(groupSpec: [
+            RbVmomi::VIM.ClusterGroupSpec(
+              operation: RbVmomi::VIM.ArrayUpdateOperation('remove'),
+              removeKey: group.name
+            )
+          ])
+          cluster.ReconfigureComputeResource_Task(spec: delete_spec, modify: true).wait_for_completion
+        end
+      end
+      class Mock
+        def destroy_group(attributes = {})
+          group = self.data[:groups][attributes[:name]]
+          raise Fog::Vsphere::Error::NotFound unless group
+          self.data[:groups].delete(attributes[:name])
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/get_host.rb
+++ b/lib/fog/vsphere/requests/compute/get_host.rb
@@ -3,6 +3,10 @@ module Fog
     class Vsphere
       class Real
 
+        def get_host(name, cluster_name, datacenter_name)
+          get_raw_host(name, cluster_name, datacenter_name)
+        end
+
         protected
 
         def get_raw_host(name, cluster_name, datacenter_name)

--- a/lib/fog/vsphere/requests/compute/list_groups.rb
+++ b/lib/fog/vsphere/requests/compute/list_groups.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def list_groups(filters = {})
+          cluster = get_raw_cluster(filters[:cluster], filters[:datacenter])
+          cluster.configurationEx.group.map {|g| group_attributes g, filters}
+        end
+
+        protected
+
+        def group_attributes(group, filters)
+          attributes = {}
+          attributes[:datacenter] = filters[:datacenter]
+          attributes[:cluster] = filters[:cluster]
+          attributes[:name] = group[:name]
+          attributes[:type] = group.class
+          if group.class.to_s == 'ClusterVmGroup' then attributes[:vm_ids] = group[:vm].map {|vm| vm.config.instanceUuid} end
+          if group.class.to_s == 'ClusterHostGroup' then attributes[:hosts] = group[:host].map {|host| host.name} end
+          return attributes
+        end
+      end
+      class Mock
+        def list_groups(filters = {})
+          self.data[:groups].values.select {|g| g[:datacenter] == filters[:datacenter] && g[:cluster] == filters[:cluster]}
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this pull request I'm adding new functionality that will be providing fog-vsphere with the ability to create, list and destroy DRS groups.  The first commit contains the changes and in the second commit I merely pulled the upstream master and merged to check for any merge conflicts.  