### PR TITLE
Do not fail on 'undefined method' when nicSettingMap not present

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -509,15 +509,14 @@ module Fog
                 custom_adapter.primaryWINS = nic['adapter']['primaryWINS'] if nic['adapter'].key?('primaryWINS')
                 custom_adapter.secondaryWINS = nic['adapter']['secondaryWINS'] if nic['adapter'].key?('secondaryWINS')
                 custom_adapter.subnetMask = nic['adapter']['subnetMask'] if nic['adapter'].key?('subnetMask')
-                
+
                 custom_adapter_mapping = RbVmomi::VIM::CustomizationAdapterMapping(:adapter => custom_adapter)
                 custom_adapter_mapping.macAddress = nic['macAddress'] if nic.key?('macAddress')
                 
-                # build the adapters array, creates it if not already created, otherwise appends to it
-                custom_nicSettingMap << custom_adapter_mapping 
+                # build the adapters array
+                custom_nicSettingMap << custom_adapter_mapping
               end
             end  
-            custom_nicSettingMap = nil if custom_nicSettingMap.length < 1
                       
             if custom_spec.key?("options") 
               # https://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.customization.Options.html


### PR DESCRIPTION
When there is no `nicSettingMap` key in `custom_spec`, it results in:

```
| NoMethodError: undefined method `length' for nil:NilClass
| /home/vagrant/.rvm/gems/ruby-2.2.4/gems/fog-vsphere-1.2.0/lib/fog/vsphere/requests/compute/vm_clone.rb:520:in `vm_clone'
```

because `custom_nicSettingMap` is nil