### PR TITLE
Upgrade rbvmomi depenency to latest stable series (1.9.x)

### DIFF
--- a/fog-vsphere.gemspec
+++ b/fog-vsphere.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.8.7'
 
   spec.add_runtime_dependency 'fog-core'
-  spec.add_runtime_dependency 'rbvmomi', '~> 1.9.0'
+  spec.add_runtime_dependency 'rbvmomi', '~> 1.9'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'pry', '~> 0.10'

--- a/fog-vsphere.gemspec
+++ b/fog-vsphere.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.8.7'
 
   spec.add_runtime_dependency 'fog-core'
-  spec.add_runtime_dependency 'rbvmomi', '~> 1.8.0'
+  spec.add_runtime_dependency 'rbvmomi', '~> 1.9.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
Puppet gem "beaker" currently can't install due to two conflicting version dependencies on the rbvmomi package. The most logical fix is to upgrade the dependency on this gem to the stable series 1.9.x , rather than downgrading Beaker's dependency version.

```
Bundler could not find compatible versions for gem "rbvmomi":
  In Gemfile:
    beaker (>= 0) ruby depends on
      rbvmomi (~> 1.9) ruby

    beaker (>= 0) ruby depends on
      fog (~> 1.38) ruby depends on
        fog-vsphere (>= 0.4.0) ruby depends on
          rbvmomi (~> 1.8.0) ruby
```

This PR increments the dependency and passes all unit tests. If happy, please upload to RubyGems ASAP since it'll break beaker in weird ways ATM, which will cause headaches for anyone unit testing Puppet modules.

It may be worth reconsidering how the dependencies are being managed for this Gem and consider pinning the major version (1.x.x) rather than the minor version (1.9.x) if the authors of rbvmomi respect semver.