### PR TITLE
vms can have more than one scsi controller

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -100,6 +100,7 @@ module Fog
       request :list_vm_customvalues
       request :list_customfields
       request :get_vm_first_scsi_controller
+      request :list_vm_scsi_controllers
       request :set_vm_customvalue
       request :vm_take_snapshot
       request :list_vm_snapshots

--- a/lib/fog/vsphere/models/compute/volumes.rb
+++ b/lib/fog/vsphere/models/compute/volumes.rb
@@ -20,7 +20,7 @@ module Fog
               raise 'volumes should have vm or template'
             end
 
-          self.each { |volume| volume.server_id = server.id }
+          self.each { |volume| volume.server = server }
           self
         end
 

--- a/lib/fog/vsphere/requests/compute/list_vm_scsi_controllers.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_scsi_controllers.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def list_vm_scsi_controllers(vm_id)
+          list_vm_scsi_controllers_raw(vm_id).map do |raw_controller|
+            Fog::Compute::Vsphere::SCSIController.new(raw_controller)
+          end
+        end
+
+        def list_vm_scsi_controllers_raw(vm_id)
+          get_vm_ref(vm_id).config.hardware.device.grep(RbVmomi::VIM::VirtualSCSIController).map do |ctrl|
+            {
+              :type    => ctrl.class.to_s,
+              :shared_bus  => ctrl.sharedBus.to_s,
+              :unit_number => ctrl.scsiCtlrUnitNumber,
+              :key => ctrl.key,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/list_vm_volumes.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_volumes.rb
@@ -38,7 +38,8 @@ module Fog
               :size => vol.capacityInKB,
               :name => vol.deviceInfo.label,
               :key => vol.key,
-              :unit_number => vol.unitNumber
+              :unit_number => vol.unitNumber,
+              :controller_key => vol.controllerKey
             }
           end
         end


### PR DESCRIPTION
This commit adds the ability to add more than one scsi controller to a vm.

This can be tested with:

```ruby
attrs = {
  ...
  :volumes => [
    {
      :storage_pod=>"Test",
      :name=>"Hard disk 1",
      :size_gb=>"10",
      :thin=>"true",
      :eager_zero=>"false",
      :controller_key => 1000
    },
    {
      :storage_pod=>"Test",
      :name=>"Hard disk 2",
      :size_gb=>"10",
      :thin=>"true",
      :eager_zero=>"false",
      :controller_key => 1001
    }
  ],
  :scsi_controllers => [
    {
      :type=>"VirtualLsiLogicController",
      :key => 1000
    },
    {
      :type=>"VirtualLsiLogicController",
      :key => 1001
    }
  ]
}

vm = client.servers.new(attrs)
vm.save
```