### PR TITLE
fixing modify_vm_volume so that it aligns with the changes in the sig…

### DIFF
--- a/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
@@ -3,17 +3,17 @@ module Fog
     class Vsphere
       class Real
         def add_vm_volume(volume)
-          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_disk(volume, volume.unit_number, :add)]})
+          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_disk(volume, :add)]})
         end
 
         def destroy_vm_volume(volume)
-          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_disk(volume, volume.unit_number, :remove)]})
+          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_disk(volume, :remove)]})
         end
       end
 
       class Mock
         def add_vm_volume(volume)
-          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_cdrom(volume, volume.unit_number, :add)]})
+          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_cdrom(volume, :add)]})
         end
 
         def destroy_vm_volume(volume)


### PR DESCRIPTION
…nature of the create_disk method that were introduced in 1.4.0.  The create_disk method no longer requires the volume.unit_number as a parameter.