### PR TITLE
set default values more reliable

### DIFF
--- a/lib/fog/vsphere/models/compute/scsicontroller.rb
+++ b/lib/fog/vsphere/models/compute/scsicontroller.rb
@@ -5,8 +5,13 @@ module Fog
         attribute :shared_bus
         attribute :type
         attribute :unit_number
-        attribute :key
+        attribute :key, :type => :integer
         attribute :server_id
+
+        def initialize(attributes = {})
+          super
+          self.key ||= 1000
+        end
 
         def to_s
           "#{type} ##{key}: shared: #{shared_bus}, unit_number: #{unit_number}"

--- a/lib/fog/vsphere/models/compute/volume.rb
+++ b/lib/fog/vsphere/models/compute/volume.rb
@@ -17,7 +17,7 @@ module Fog
         attribute :size_gb
         attribute :key
         attribute :unit_number
-        attribute :controller_key, :type => :integer, :default => 1000
+        attribute :controller_key, :type => :integer
 
         def initialize(attributes={})
           super defaults.merge(attributes)
@@ -93,7 +93,8 @@ module Fog
           {
             :thin => true,
             :name => "Hard disk",
-            :mode => "persistent"
+            :mode => "persistent",
+            :controller_key => 1000
           }
         end
 


### PR DESCRIPTION
fog-core sets these attributes "too late" and this can cause issues.