### PR TITLE
get_vm_folder_name: Don't crash when VMs disappear

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
+++ b/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
@@ -40,12 +40,23 @@ module Fog
           if name.include?('/')
             folder = File.dirname(name)
             basename = File.basename(name)
-            vms.find { |v| v["name"] == basename && v.parent.pretty_path.include?(folder) }
+            vms.find do |v|
+              begin
+                v["name"] == basename && v.parent.pretty_path.include?(folder)
+              rescue RbVmomi::VIM::ManagedObjectNotFound
+                false
+              end
+            end
           else
-            vms.find { |v| v["name"] == name }
+            vms.find do |v|
+              begin
+                v["name"] == name
+              rescue RbVmomi::VIM::ManagedObjectNotFound
+                false
+              end
+            end
           end
-        end        
-        
+        end
       end
 
       class Mock


### PR DESCRIPTION
Since we fetch the list of all VMs first and then iterate over them we might
crash since VSphere refuses to report properly on VMs that are being created or
removed and we're doing API calls for each VM until we found a matching one:

/home/test-vspehere/vendor/ruby/2.1.0/gems/rbvmomi-1.9.4/lib/rbvmomi/connection.rb:61:in `parse_response': ManagedObjectNotFound: Das Objekt wurde bereits gel??scht oder noch nicht vollst??ndig erstellt (RbVmomi::Fault)
	from /home/test-vspehere/vendor/ruby/2.1.0/gems/rbvmomi-1.9.4/lib/rbvmomi/connection.rb:90:in `call'
	from /home/test-vspehere/vendor/ruby/2.1.0/gems/rbvmomi-1.9.4/lib/rbvmomi/basic_types.rb:211:in `_call'
	from /home/test-vspehere/vendor/ruby/2.1.0/gems/rbvmomi-1.9.4/lib/rbvmomi/basic_types.rb:74:in `block (2 levels) in init'
	from /home/test-vspehere/vendor/ruby/2.1.0/gems/rbvmomi-1.9.4/lib/rbvmomi/basic_types.rb:189:in `_get_property'
	from /home/test-vspehere/vendor/ruby/2.1.0/gems/rbvmomi-1.9.4/lib/rbvmomi/basic_types.rb:223:in `[]'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:43:in `block in get_vm_by_name'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:43:in `each'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:43:in `find'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:43:in `get_vm_by_name'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:25:in `block in get_vm_ref'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:25:in `map'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:25:in `get_vm_ref'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb:45:in `get_raw_interfaces'
	from /home/test-vspehere/vendor/ruby/2.1.0/bundler/gems/.git-642cc3d5fa47/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb:32:in `list_vm_interfaces'
	from ./test.rb:62:in `main'
	from ./test.rb:67:in `<main>'

This is triggerable if you create several VMs at a time and call
list_vm_interfaces in a tight loop.