### PR TITLE
Do not fail when cloning from template to different cluster

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -115,6 +115,10 @@ module Fog
             cluster_name = options['resource_pool'][0]
             pool_name = options['resource_pool'][1]
             resource_pool = get_raw_resource_pool(pool_name, cluster_name, options['datacenter'])
+          elsif ( options.key?('resource_pool') && options['resource_pool'].is_a?(Array) && options['resource_pool'].length == 2 && options['resource_pool'][1] == 'Resources')
+            cluster_name = options['resource_pool'][0]
+            pool_name = options['resource_pool'][1]
+            resource_pool = get_raw_resource_pool(nil, cluster_name, options['datacenter'])
           elsif ( vm_mob_ref.resourcePool == nil )
             # If the template is really a template then there is no associated resource pool,
             # so we need to find one using the template's parent host or cluster


### PR DESCRIPTION
Resolves #69 by calling the target cluster resource pool, instead of the template's host's resource pool, when using the default resource pool.