### PR TITLE
fix vm clone with resource pool

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -133,7 +133,7 @@ module Fog
           # Options['host']<~String>
           # The target host for the virtual machine. Optional.
           if options.key?('host') && !options['host'].empty? && !cluster_name.nil?
-            host = get_raw_host(options['host'], attributes[:cluster], options['datacenter'])
+            host = get_raw_host(options['host'], cluster_name, options['datacenter'])
           else
             host = nil
           end


### PR DESCRIPTION
there is no attributes variable in vm_clone, cluster_name should be used