### PR TITLE
Add ability to detach volume from VM

### DIFF
--- a/lib/fog/vsphere/models/compute/volume.rb
+++ b/lib/fog/vsphere/models/compute/volume.rb
@@ -36,6 +36,14 @@ module Fog
           name
         end
 
+        def detach
+          requires :server_id, :key, :unit_number
+
+          service.remove_vm_volume(self)
+          server.volumes -= [self]
+          true
+        end
+
         def destroy
           requires :server_id, :key, :unit_number
 

--- a/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
@@ -6,8 +6,14 @@ module Fog
           vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_disk(volume, :add)]})
         end
 
-        def destroy_vm_volume(volume)
+        def remove_vm_volume(volume)
           vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_disk(volume, :remove)]})
+        end
+
+        def destroy_vm_volume(volume)
+          vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {
+            'deviceChange'=>[create_disk(volume, :remove, file_operation: :destroy)]
+          })
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_volume.rb
@@ -22,6 +22,10 @@ module Fog
           vm_reconfig_hardware('instance_uuid' => volume.server_id, 'hardware_spec' => {'deviceChange'=>[create_cdrom(volume, :add)]})
         end
 
+        def remove_vm_volume(volume)
+          true
+        end
+
         def destroy_vm_volume(volume)
           true
         end

--- a/lib/fog/vsphere/requests/compute/vm_reconfig_volumes.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reconfig_volumes.rb
@@ -9,16 +9,7 @@ module Fog
             deviceChange: []
           }
           options['volumes'].each do |volume|
-            hardware_spec[:deviceChange].push({
-              :operation=>:edit,
-              device: RbVmomi::VIM::VirtualDisk(
-                backing: RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo( diskMode: volume.mode, fileName: volume.filename ),
-                unitNumber: volume.unit_number,
-                key: volume.key,
-                controllerKey: volume.controller_key,
-                capacityInKB: volume.size,
-              )
-            })
+            hardware_spec[:deviceChange].push(create_disk(volume, :edit, filename: volume.filename))
           end
           vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
         end


### PR DESCRIPTION
- Add detach to volume model
- Add remove_vm_volume as a request, it remove volume from vm without deleting file
- Refactored create_disk so it can be used for remove volume without deleting file, and reuse it in vm_reconfig_volumes request