### PR TITLE
Properly escape DC names

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_clusters.rb
+++ b/lib/fog/vsphere/requests/compute/list_clusters.rb
@@ -41,7 +41,7 @@ module Fog
 
         def cluster_path(cluster, datacenter_name)
           datacenter = find_raw_datacenter(datacenter_name)
-          cluster.pretty_path.gsub(/(#{datacenter_name}|#{datacenter.hostFolder.name})\//,'')
+          cluster.pretty_path.gsub(/(#{Regexp.escape(datacenter_name)}|#{Regexp.escape(datacenter.hostFolder.name)})\//,'')
         end
       end
 


### PR DESCRIPTION
This causes problems when DC name contains characters that have extra meaning in regular expressions e.g. parenthesis. The prefix is not matched and the full name contains also DC name. Later when we search for such cluster, it can't be found.