### PR TITLE
fix snapshots.get(id) when no snapshot is found

### DIFF
--- a/lib/fog/vsphere/models/compute/snapshots.rb
+++ b/lib/fog/vsphere/models/compute/snapshots.rb
@@ -21,8 +21,9 @@ module Fog
         def get(snapshot_ref)
           all.each do |snapshot|
             snapshot = snapshot.get_child(snapshot_ref)
-            break snapshot if snapshot
+            return snapshot if snapshot
           end
+          nil
         end
       end
     end


### PR DESCRIPTION
My previous commit fixed snapshots.get for existing id, but broke it for unexisting id, it was returning snapshots array instead of nil