### PR TITLE
add connected attribute to interface

### DIFF
--- a/lib/fog/vsphere/models/compute/interface.rb
+++ b/lib/fog/vsphere/models/compute/interface.rb
@@ -10,6 +10,7 @@ module Fog
         attribute :network
         attribute :name
         attribute :status
+        attribute :connected
         attribute :summary
         attribute :type
         attribute :key

--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -67,6 +67,7 @@ module Fog
             :mac     => nic.macAddress,
             :network => nic.backing.respond_to?("network") ? nic.backing.network.name : nic.backing.port.portgroupKey,
             :status  => nic.connectable.status,
+            :connnected => nic.connectable.connected,
             :summary => nic.deviceInfo.summary,
             :type    => nic.class,
             :key     => nic.key,

--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -67,7 +67,7 @@ module Fog
             :mac     => nic.macAddress,
             :network => nic.backing.respond_to?("network") ? nic.backing.network.name : nic.backing.port.portgroupKey,
             :status  => nic.connectable.status,
-            :connnected => nic.connectable.connected,
+            :connected => nic.connectable.connected,
             :summary => nic.deviceInfo.summary,
             :type    => nic.class,
             :key     => nic.key,


### PR DESCRIPTION
add connected attribute from RbVmomi::VIM::VirtualDeviceConnectInfo (raw.connectable.connected)


