### PR TITLE
Updated list_clusters to have an optional param or allow filtering on datacenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmp
 *.a
 mkmf.log
 gemfiles/*.lock
+.*.swp

--- a/lib/fog/vsphere/requests/compute/list_clusters.rb
+++ b/lib/fog/vsphere/requests/compute/list_clusters.rb
@@ -6,7 +6,7 @@ module Fog
         def list_clusters(filters = {})
           datacenter_name = filters[:datacenter] if filters.key? :datacenter
           if datacenter_name.nil?
-            list_datacenters.map { |dc| list_clusters(datacenter: dc[:name]) }.flatten
+            list_datacenters.map { |dc| list_clusters(:datacenter => dc[:name]) }.flatten
           else
             raw_clusters(datacenter_name).map do |cluster|
               if cluster.instance_of? RbVmomi::VIM::ClusterComputeResource
@@ -35,13 +35,13 @@ module Fog
 
         def cluster_attributes(cluster, datacenter_name)
           {
-            id: managed_obj_id(cluster),
-            name: cluster.name,
-            full_path: cluster_path(cluster, datacenter_name),
-            num_host: cluster.summary.numHosts,
-            num_cpu_cores: cluster.summary.numCpuCores,
-            overall_status: cluster.summary.overallStatus,
-            datacenter: datacenter_name || parent_attribute(cluster.path, :datacenter)[1]
+            :id => managed_obj_id(cluster),
+            :name => cluster.name,
+            :full_path => cluster_path(cluster, datacenter_name),
+            :num_host => cluster.summary.numHosts,
+            :num_cpu_cores => cluster.summary.numCpuCores,
+            :overall_status => cluster.summary.overallStatus,
+            :datacenter => datacenter_name || parent_attribute(cluster.path, :datacenter)[1]
           }
         end
 

--- a/tests/class_from_string_tests.rb
+++ b/tests/class_from_string_tests.rb
@@ -4,11 +4,11 @@ class A; class B; class C; end; end; end
 
 class TestClassFromString < Minitest::Test
   def test_empty_string
-    assert_equal(nil, Fog::Vsphere.class_from_string(''))
+    assert_nil(Fog::Vsphere.class_from_string(''))
   end
 
   def test_nil
-    assert_equal(nil, Fog::Vsphere.class_from_string(nil))
+    assert_nil(Fog::Vsphere.class_from_string(nil))
   end
 
   def test_name_as_class
@@ -20,7 +20,7 @@ class TestClassFromString < Minitest::Test
   end
 
   def test_unexpected_input
-    assert_equal(nil, Fog::Vsphere.class_from_string(8))
+    assert_nil(Fog::Vsphere.class_from_string(8))
   end
 
   def test_nested_class_without_default_path


### PR DESCRIPTION
This shouldn't be a breaking change, old behavior is retained while allowing you to not pass a datacenter parameter. It also ensures that only `RbVmomi::VIM::ClusterComputeResources` are returned as clusters. No more pesky standalone hosts!