### PR TITLE
server can acquire webmks ticket

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -49,6 +49,8 @@ module Fog
       collection :rules
       model :host
       collection :hosts
+      model :ticket
+      collection :tickets
 
       request_path 'fog/vsphere/requests/compute'
       request :current_time
@@ -123,6 +125,7 @@ module Fog
       request :modify_vm_controller
       request :vm_revert_snapshot
       request :vm_remove_snapshot
+      request :vm_acquire_ticket
 
       module Shared
         attr_reader :vsphere_is_vcenter

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -324,6 +324,10 @@ module Fog
           (path.split('/').reject {|e| e.empty?} - ["Datacenters", datacenter, "vm"]).join("/")
         end
 
+        def acquire_ticket(type = nil)
+          service.tickets(:server => self).create
+        end
+
         private
 
         def defaults

--- a/lib/fog/vsphere/models/compute/ticket.rb
+++ b/lib/fog/vsphere/models/compute/ticket.rb
@@ -1,0 +1,17 @@
+require 'fog/compute/models/server'
+
+module Fog
+  module Compute
+    class Vsphere
+      class Ticket < Fog::Model
+
+        attribute :server_id
+
+        attribute :ticket
+        attribute :host
+        attribute :port
+        attribute :ssl_thumbprint
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/models/compute/tickets.rb
+++ b/lib/fog/vsphere/models/compute/tickets.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Tickets < Fog::Collection
+        autoload :Ticket, File.expand_path('../ticket', __FILE__)
+
+        model Fog::Compute::Vsphere::Ticket
+
+        attr_accessor :server
+
+        def create(opts = {})
+          requires :server
+          raise 'server must be a Fog::Compute::Vsphere::Server' unless server.is_a?(Fog::Compute::Vsphere::Server)
+          new(
+            service.vm_acquire_ticket(
+              opts.merge(
+                'instance_uuid' => server.instance_uuid
+              )
+            )
+          )
+        end
+     end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/vm_acquire_ticket.rb
+++ b/lib/fog/vsphere/requests/compute/vm_acquire_ticket.rb
@@ -1,0 +1,34 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def vm_acquire_ticket(options = {})
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.key?('instance_uuid')
+          ticket_type = options['ticket_type'] || 'webmks'
+
+          vm_mob_ref = get_vm_ref(options['instance_uuid'])
+
+          ticket = vm_mob_ref.AcquireTicket(:ticketType => ticket_type)
+          {
+            'ticket' => ticket.ticket,
+            'host' => ticket.host,
+            'port' => ticket.port,
+            'ssl_thumbprint' => ticket.sslThumbprint
+          }
+        end
+      end
+
+      class Mock
+        def vm_acquire_ticket(options = {})
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.key?('instance_uuid')
+          {
+            'ticket' => 'fdsfdsf',
+            'host' => 'esxi.example.com',
+            'port' => 443,
+            'ssl_thumbprint' => '1C:63:E1:BD:56:03:EB:44:85:12:12:FC:DA:40:11:65:0E:30:A1:B8'
+          }
+        end
+      end
+    end
+  end
+end

--- a/tests/models/compute/server_tests.rb
+++ b/tests/models/compute/server_tests.rb
@@ -36,6 +36,9 @@ Shindo.tests('Fog::Compute[:vsphere] | server model', ['vsphere']) do
           end
         end
       end
+      test('tickets') do
+        test('acquire ticket successfully') { server.acquire_ticket.kind_of? Fog::Compute::Vsphere::Ticket }
+      end
     end
     tests('have attributes') do
       model_attribute_hash = server.attributes

--- a/tests/models/compute/ticket_tests.rb
+++ b/tests/models/compute/ticket_tests.rb
@@ -1,0 +1,14 @@
+Shindo.tests('Fog::Compute[:vsphere] | hosts collection', ['vsphere']) do
+
+  servers = Fog::Compute[:vsphere].servers
+  server = servers.last
+  ticket = server.acquire_ticket
+
+  tests('A ticket') do
+    test('should have a ticket') { not ticket.ticket.empty? }
+    test('should have a host') { not ticket.host.empty? }
+    test('should have a port') { ticket.port.kind_of? Fixnum }
+    test('should have a ssl ssl_thumbprint') { not ticket.ssl_thumbprint.empty? }
+  end
+
+end

--- a/tests/models/compute/tickets_tests.rb
+++ b/tests/models/compute/tickets_tests.rb
@@ -1,0 +1,10 @@
+Shindo.tests('Fog::Compute[:vsphere] | hosts collection', ['vsphere']) do
+
+  service = Fog::Compute[:vsphere]
+  server = service.servers.last
+
+  tests('The tickets collection') do
+    test('should create a ticket for a server') { service.tickets(:server => server).create.kind_of? Fog::Compute::Vsphere::Ticket }
+  end
+
+end


### PR DESCRIPTION
This patch allows to acquire a webmks ticket for a server. This can be used with https://www.vmware.com/support/developer/html-console/.