### PR TITLE
Fixed validation for power on/off requests (foreman)

### DIFF
--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -97,7 +97,7 @@ module Fog
 
         def start(options = {})
           requires :instance_uuid
-          service.vm_power_on('instance_uuid' => instance_uuid) unless power_state == ready?
+          service.vm_power_on('instance_uuid' => instance_uuid) unless ready?
         end
 
         def stop(options = {})

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -97,13 +97,13 @@ module Fog
 
         def start(options = {})
           requires :instance_uuid
-          service.vm_power_on('instance_uuid' => instance_uuid)
+          service.vm_power_on('instance_uuid' => instance_uuid) unless power_state == ready?
         end
 
         def stop(options = {})
           options = { :force => !tools_installed? || !tools_running? }.merge(options)
           requires :instance_uuid
-          service.vm_power_off('instance_uuid' => instance_uuid, 'force' => options[:force])
+          service.vm_power_off('instance_uuid' => instance_uuid, 'force' => options[:force]) unless power_state == 'poweredOff'
         end
 
         def suspend(options = {})


### PR DESCRIPTION
Total n00b here to Git.  Done quite a bit of Ruby coding, so if I've done something incorrect as far as preferred Git process goes, please correct my behavior and I'll correct it the next time!

I found via Foreman that trying to power off an already powered off system, resulted in a 500 internal server error.  This is simple validation to not run the start/stop operations via RbVmomi if they are already in their desired state.