### PR TITLE
vm clone: generate new mac addresses

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -721,6 +721,8 @@ module Fog
             if new_nic
               backing = create_nic_backing(new_nic, {})
               template_nic.backing = backing
+              template_nic.addressType = 'generated'
+              template_nic.macAddress = nil
               connectable = RbVmomi::VIM::VirtualDeviceConnectInfo(
                 :allowGuestControl => true,
                 :connected => true,


### PR DESCRIPTION
https://github.com/fog/fog-vsphere/pull/98 introduced a regression that leads to duplicate mac addressed because the cloned host keeps the mac addresses of the parent host.
This forces the generation of new mac addresses during cloning.