### PR TITLE
Drop Ruby<2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     - rvm: jruby-head
   fast_finish: true
   include:
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.1.9.2+
     - rvm: 2.0.0
       gemfile: Gemfile
     - rvm: 2.1.10
@@ -18,8 +16,6 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.4.0
       gemfile: Gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/Gemfile.1.9.2+
     - rvm: jruby-head
       gemfile: Gemfile
 notifications:

--- a/fog-vsphere.gemspec
+++ b/fog-vsphere.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.8.7'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'fog-core'
   spec.add_runtime_dependency 'rbvmomi', '~> 1.9'

--- a/gemfiles/Gemfile.1.9.2+
+++ b/gemfiles/Gemfile.1.9.2+
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'codeclimate-test-reporter', '~> 1.0',  group: :test, require: nil
-gem 'json',    '~> 1.8.0'
-gem 'net-ssh', '~> 2.9'
-gem 'rubocop', '~> 0.41.0'
-gem 'simplecov', '~> 0.12.0'
-
-gemspec :path => '..'


### PR DESCRIPTION
Users requiring Ruby 1.9 support should use the fog gem.