### PR TITLE
Fixes listing resource pools for clusters nested in folders

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -437,6 +437,7 @@ module Fog
                   :num_cpu_cores => "16",
                   :overall_status => "green",
                   :datacenter => "Solutions",
+                  :full_path => 'Solutionscluster',
                   :klass => "RbVmomi::VIM::ComputeResource"
                  },
                  {:id => "e4195973-102b-4096-bbd6-5429ff0b35c9",
@@ -445,6 +446,7 @@ module Fog
                   :num_cpu_cores => "32",
                   :overall_status => "green",
                   :datacenter => "Solutions",
+                  :full_path => 'Problemscluster',
                   :klass => "RbVmomi::VIM::ComputeResource"
                  },
                  {
@@ -455,6 +457,7 @@ module Fog
                                   :num_cpu_cores => "32",
                                   :overall_status => "green",
                                   :datacenter => "Solutions",
+                                  :full_path => 'Nested/Problemscluster',
                                   :klass => "RbVmomi::VIM::ComputeResource"
                                  },
                                  {:id => "03616b8d-b707-41fd-b3b5-the Second",
@@ -463,6 +466,7 @@ module Fog
                                   :num_cpu_cores => "32",
                                   :overall_status => "green",
                                   :datacenter => "Solutions",
+                                  :full_path => 'Nested/Lastcluster',
                                   :klass => "RbVmomi::VIM::ComputeResource"}
                    ]
                  }

--- a/lib/fog/vsphere/models/compute/cluster.rb
+++ b/lib/fog/vsphere/models/compute/cluster.rb
@@ -14,7 +14,7 @@ module Fog
         def resource_pools(filters = { })
           self.attributes[:resource_pools] ||= id.nil? ? [] : service.resource_pools({
                                                                                           :service => service,
-                                                                                          :cluster    => name,
+                                                                                          :cluster    => full_path,
                                                                                           :datacenter => datacenter
                                                                                         }.merge(filters))
         end
@@ -22,7 +22,7 @@ module Fog
         def datastores(filters = { })
           self.attributes[:datastores] ||= id.nil? ? [] : service.datastores({
                                                                                           :service => service,
-                                                                                          :cluster    => name,
+                                                                                          :cluster    => full_path,
                                                                                           :datacenter => datacenter
                                                                                         }.merge(filters))
         end
@@ -30,17 +30,17 @@ module Fog
         def networks(filters = { })
           self.attributes[:networks] ||= id.nil? ? [] : service.networks({
                                                                                           :service => service,
-                                                                                          :cluster    => name,
+                                                                                          :cluster    => full_path,
                                                                                           :datacenter => datacenter
                                                                                         }.merge(filters))
         end
 
         def rules
-          service.rules(:datacenter => datacenter, :cluster => name)
+          service.rules(:datacenter => datacenter, :cluster => full_path)
         end
 
         def hosts
-          service.hosts(:datacenter => datacenter, :cluster => name)
+          service.hosts(:datacenter => datacenter, :cluster => full_path)
         end
 
         def to_s


### PR DESCRIPTION
It currently isn't possible to list cluster's resources when the cluster is nested in a folder. This PR fixes it by using `full_path` (eg. `"nested/folder/cluster"`) instead of `name` (eg. just `"cluster"`) as a cluster identifier in the resource queries.