### PR TITLE
ensure views are destroyed after use

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -648,6 +648,30 @@ module Fog
             raise Fog::Vsphere::Errors::SecurityError, "The remote system presented a public key with hash #{pubkey_hash} but we're expecting a hash of #{expected_pubkey_hash || '<unset>'}.  If you are sure the remote system is authentic set vsphere_expected_pubkey_hash: <the hash printed in this message> in ~/.fog"
           end
         end
+
+        def list_container_view(datacenter_obj_or_name, type, container_object = nil)
+          dc = if datacenter_obj_or_name.kind_of?(String)
+                 find_raw_datacenter(datacenter_obj_or_name)
+               else
+                 datacenter_obj_or_name
+               end
+
+          container = if container_object
+                        dc.public_send(container_object)
+                      else
+                        dc
+                      end
+
+          container_view = connection.serviceContent.viewManager.CreateContainerView(
+            :container  => dc,
+            :type       =>  [type],
+            :recursive  => true
+          )
+
+          result = container_view.view
+          container_view.DestroyView
+          result
+        end
       end
     end
   end

--- a/lib/fog/vsphere/requests/compute/get_datastore.rb
+++ b/lib/fog/vsphere/requests/compute/get_datastore.rb
@@ -11,13 +11,11 @@ module Fog
         protected
 
         def get_raw_datastore(name, datacenter_name)
-          dc = find_raw_datacenter(datacenter_name)
+          get_raw_datastores(datacenter_name).detect { |ds| ds.name == name }
+        end
 
-          connection.serviceContent.viewManager.CreateContainerView({
-            :container  => dc.datastoreFolder,
-            :type       =>  ["Datastore"],
-            :recursive  => true
-          }).view.select{|ds| ds.name == name}.first
+        def get_raw_datastores(datacenter_name)
+          list_container_view(datacenter_name, 'Datastore', :datastoreFolder)
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -12,8 +12,7 @@ module Fog
 
         def get_raw_network(name, datacenter_name, distributedswitch=nil)
           finder = choose_finder(name, distributedswitch)
-          networks = get_all_raw_networks(datacenter_name)
-          networks.find { |n| finder.call(n) }
+          get_all_raw_networks(datacenter_name).find { |n| finder.call(n) }
         end
       end
 
@@ -22,13 +21,7 @@ module Fog
         protected
 
         def get_all_raw_networks(datacenter_name)
-          dc = find_raw_datacenter(datacenter_name)
-          connection.serviceContent.viewManager.
-            CreateContainerView({
-                                 :container => dc.networkFolder,
-                                 :type =>      ["Network"],
-                                 :recursive => true
-                                }).view
+          list_container_view(datacenter_name, 'Network', :networkFolder)
         end
 
         def choose_finder(name, distributedswitch)

--- a/lib/fog/vsphere/requests/compute/get_storage_pod.rb
+++ b/lib/fog/vsphere/requests/compute/get_storage_pod.rb
@@ -11,19 +11,13 @@ module Fog
         protected
 
         def get_raw_storage_pod(name, datacenter_name)
-          dc = find_raw_datacenter(datacenter_name)
-
-          connection.serviceContent.viewManager.CreateContainerView({
-            :container  => dc,
-            :type       => ["StoragePod"],
-            :recursive  => true
-          }).view.select{|pod| pod.name == name}.first
+          raw_storage_pods(datacenter_name).detect { |pod| pod.name == name}
         end
       end
 
       class Mock
         def get_storage_pod(name, datacenter_name)
-          list_storage_pods({datacenter: datacenter_name}).select{|h| h[:name] == name }.first
+          list_storage_pods({datacenter: datacenter_name}).detect { |h| h[:name] == name }
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_storage_pods.rb
+++ b/lib/fog/vsphere/requests/compute/list_storage_pods.rb
@@ -10,18 +10,14 @@ module Fog
         end
 
         private
-        def raw_storage_pods(datacenter_name)
-          dc = find_raw_datacenter(datacenter_name)
 
-          connection.serviceContent.viewManager.CreateContainerView({
-            :container  => dc,
-            :type       => ["StoragePod"],
-            :recursive  => true
-          }).view
+        def raw_storage_pods(datacenter_name)
+          list_container_view(datacenter_name, 'StoragePod')
         end
+
         protected
 
-        def storage_pod_attributes storage_pod, datacenter
+        def storage_pod_attributes(storage_pod, datacenter)
           {
             :id          => managed_obj_id(storage_pod),
             :name        => storage_pod.name,

--- a/lib/fog/vsphere/requests/compute/list_templates.rb
+++ b/lib/fog/vsphere/requests/compute/list_templates.rb
@@ -27,14 +27,10 @@ module Fog
           datacenters = find_datacenters(options[:datacenter])
 
           vms = datacenters.map do |dc|
-            connection.serviceContent.viewManager.CreateContainerView({
-              :container  => dc.vmFolder,
-              :type       =>  ["VirtualMachine"],
-              :recursive  => true
-            }).view
+            list_container_view(dc, 'VirtualMachine', :vmFolder)
           end.flatten
           # remove all virtual machines that are not templates
-          vms.delete_if { |v| v.config.nil? or not v.config.template }
+          vms.delete_if { |v| v.config.nil? || !v.config.template }
 
           vms.map(&method(:convert_vm_mob_ref_to_attr_hash))
         end

--- a/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
+++ b/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
@@ -23,15 +23,15 @@ module Fog
         def list_all_virtual_machines_in_folder(path, datacenter_name, recursive)
           vms = raw_list_all_virtual_machines_in_folder(path, datacenter_name, recursive).to_a
           # remove all template based virtual machines
-          vms.delete_if { |v| v.config.nil? or v.config.template }
+          vms.delete_if { |v| v.config.nil? || v.config.template }
           vms.map(&method(:convert_vm_mob_ref_to_attr_hash))
         end
-        
+
         def raw_list_all_virtual_machines_in_folder(path, datacenter_name, recursive)
           folder = get_raw_vmfolder(path, datacenter_name)
           folder_enumerator(folder, recursive)
         end
-        
+
         # An enumerator for a folder. Enumerates all the VMs in the folder, recursively if
         # passed recursive=true
         def folder_enumerator(raw_folder, recursive)
@@ -46,7 +46,7 @@ module Fog
             end
           end
         end
-        
+
         def list_all_virtual_machines(options = { })
           raw_vms = raw_list_all_virtual_machines(options[:datacenter])
           vms = convert_vm_view_to_attr_hash(raw_vms)
@@ -62,17 +62,11 @@ module Fog
           ## much faster to interact for some functions.
           datacenters = find_datacenters(datacenter_name)
           datacenters.map do |dc|
-            connection.serviceContent.viewManager.CreateContainerView({
-                                                                           :container  => dc.vmFolder,
-                                                                           :type       =>  ["VirtualMachine"],
-                                                                           :recursive  => true
-                                                                       }).view
+            list_container_view(dc, 'VirtualMachine', :vmFolder)
           end.flatten
         end
         def get_folder_path(folder, root = nil)
-          if (not folder.methods.include?('parent')) or (folder == root)
-            return
-          end
+          return if (!folder.methods.include?('parent')) || (folder == root)
           "#{get_folder_path(folder.parent)}/#{folder.name}"
         end
       end


### PR DESCRIPTION
fog-vsphere uses Views to get data from vSphere. These views need to be closed manually or they will pile up and waste resources on the vCenter. This can cause problems when there are no more free resources for other services (eg. NSX Manager) that require them.