### PR TITLE
rescue nil for retrieving vm.config.instanceUuid (fixes #123)

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_hosts.rb
+++ b/lib/fog/vsphere/requests/compute/list_hosts.rb
@@ -27,7 +27,7 @@ module Fog
             product_version: host.summary.config.product.version,
             hostname:        (host.config.network.dnsConfig.hostName rescue nil),
             domainname:      (host.config.network.dnsConfig.domainName rescue nil),
-            vm_ids:          Proc.new { host[:vm].map {|vm| vm.config.instanceUuid } }
+            vm_ids:          Proc.new { host[:vm].map {|vm| vm.config.instanceUuid rescue nil} }
           }
         end
       end


### PR DESCRIPTION
rescue nil for retrieving vm.config.instanceUuid if somehow the VM is not able to be retrieved (nil class for VM)