### PR TITLE
networks have vlanId property

### DIFF
--- a/lib/fog/vsphere/models/compute/network.rb
+++ b/lib/fog/vsphere/models/compute/network.rb
@@ -8,6 +8,7 @@ module Fog
         attribute :datacenter
         attribute :accessible # reachable by at least one hypervisor
         attribute :virtualswitch
+        attribute :vlanid
 
         def to_s
           name


### PR DESCRIPTION
This PR adds a new property `vlanId` to the network model. In addition, it also speeds up network listing a lot by not calling `get_raw_network` on a raw network.

@chris1984: Do you mind taking a look?

This can be tested like this:

```
require 'fog'

client = ::Fog::Compute.new(
  :provider => 'vsphere',
  :vsphere_username => 'ccc',
  :vsphere_password => 'ccc',
  :vsphere_server => 'ccc',
  :vsphere_expected_pubkey_hash => 'ccc'
)

datacenter_name = 'World'

dc = client.datacenters.get(datacenter_name)

dc.clusters.first.networks.all
```

This can be optimized further, but let's keep this simple for now.