### PR TITLE
improve host listing performance

### DIFF
--- a/lib/fog/vsphere/models/compute/host.rb
+++ b/lib/fog/vsphere/models/compute/host.rb
@@ -6,13 +6,19 @@ module Fog
 
         attribute :datacenter
         attribute :cluster
-        attribute :name
-        attribute :vm_ids
         attribute :cpu_cores
         attribute :cpu_sockets
         attribute :cpu_threads
         attribute :memory
         attribute :uuid
+        attribute :ipaddress
+        attribute :ipaddress6
+        attribute :model
+        attribute :vendor
+        attribute :product_name
+        attribute :product_version
+        attribute :hostname
+        attribute :domainname
 
         # Lazy Loaded Attributes
         [:vm_ids].each do |attr|


### PR DESCRIPTION
This improves host listing via a property collector. This can be optimized even further, but it's a start. :-)

This can be tested with something like this:

```ruby
require 'fog'

client = ::Fog::Compute.new(
  :provider => 'vsphere',
  :vsphere_username => 'ccc',
  :vsphere_password => 'ccc',
  :vsphere_server => 'ccc',
  :vsphere_expected_pubkey_hash => 'ccc'
)

datacenter_name = 'World'

dc = client.datacenters.get(datacenter_name)

dc.clusters.first.hosts.all
```

We can use this code as a basis to retrieve other attributes faster.