### PR TITLE
vm_clone: pass datacenter to nic backing

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -751,7 +751,7 @@ module Fog
 
           template_nics.zip(modified_nics).each do |template_nic, new_nic|
             if new_nic
-              backing = create_nic_backing(new_nic, {})
+              backing = create_nic_backing(new_nic, {datacenter: datacenter})
               template_nic.backing = backing
               template_nic.addressType = 'generated'
               template_nic.macAddress = nil


### PR DESCRIPTION
This fixes

```
NoMethodError: undefined method `networkFolder' for nil:NilClass
  fog-vsphere/lib/fog/vsphere/compute.rb:674:in `public_send'
  fog-vsphere/lib/fog/vsphere/compute.rb:674:in `list_container_view'
  fog-vsphere/lib/fog/vsphere/requests/compute/get_network.rb:24:in `get_all_raw_networks'
  fog-vsphere/lib/fog/vsphere/requests/compute/get_network.rb:15:in `get_raw_network'
  fog-vsphere/lib/fog/vsphere/requests/compute/create_vm.rb:167:in `create_nic_backing'
  fog-vsphere/lib/fog/vsphere/requests/compute/vm_clone.rb:754:in `block in modify_template_nics_specs'
  fog-vsphere/lib/fog/vsphere/requests/compute/vm_clone.rb:752:in `each'
  fog-vsphere/lib/fog/vsphere/requests/compute/vm_clone.rb:752:in `modify_template_nics_specs'
  fog-vsphere/lib/fog/vsphere/requests/compute/vm_clone.rb:158:in `vm_clone'
```