### PR TITLE
Add vm_update class for improved vm reconfiguration

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -83,6 +83,7 @@ module Fog
       request :get_folder
       request :list_folders
       request :create_vm
+      request :update_vm
       request :list_vm_interfaces
       request :modify_vm_interface
       request :modify_vm_volume

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -295,14 +295,10 @@ module Fog
         def save
           requires :name, :cluster, :datacenter
           if persisted?
-            vm_rename if attribute_changed?(:name)
-            vm_reconfig_cpus if attribute_changed?(:cpus) || attribute_changed?(:corespersocket)
-            vm_reconfig_memory if attribute_changed?(:memory_mb)
-            vm_reconfig_volumes if attribute_changed?(:volumes)
+            service.update_vm(self)
           else
             self.id = service.create_vm(attributes)
           end
-          @old = nil
           reload
         end
 
@@ -373,14 +369,6 @@ module Fog
               Fog::Compute::Vsphere::SCSIController.new
             ]
           end
-        end
-
-        def attribute_changed?(attr)
-          attributes.reject { |k, v| old.attributes[k] == v }.key?(attr)
-        end
-
-        def old
-          @old ||= dup.reload
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -28,16 +28,15 @@ module Fog
           when String
             # only the one will do
             proc do |n|
-              (n.name == name) &&
-                (n.class.to_s == 'DistributedVirtualPortgroup') &&
+              n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == name || n.key == name) &&
                 (n.config.distributedVirtualSwitch.name == distributedswitch)
             end
           when :dvs
             # the first distributed virtual switch will do - selected by network - gives control to vsphere
-            proc { |n| (n.name == name) && (n.class.to_s == 'DistributedVirtualPortgroup') }
+            proc { |n| (n.name == name || n.key == name) && (n.class.to_s == 'DistributedVirtualPortgroup') }
           else
             # the first matching network will do, seems like the non-distributed networks come first
-            proc { |n| (n.name == name) }
+            proc { |n| (n.name == name || (n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && n.key == name)) }
           end
         end
       end

--- a/lib/fog/vsphere/requests/compute/update_vm.rb
+++ b/lib/fog/vsphere/requests/compute/update_vm.rb
@@ -1,0 +1,111 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def update_vm(server)
+          attributes = server.attributes
+          datacenter = attributes[:datacenter]
+          vm_mob_ref = get_vm_ref(attributes[:instance_uuid], datacenter)
+
+          device_change = []
+          spec = {}
+
+          # Name
+          spec[:name] = attributes[:name]
+
+          # CPUs
+          spec[:numCPUs] = attributes[:cpus]
+          spec[:numCoresPerSocket] = attributes[:corespersocket]
+
+          # Memory
+          spec[:memoryMB] = attributes[:memory_mb]
+
+          # Volumes
+          device_change.concat(update_vm_volumes_specs(vm_mob_ref, server.volumes))
+
+          # Networks
+          device_change.concat(update_vm_interfaces_specs(vm_mob_ref, server.interfaces, datacenter))
+
+          spec[:deviceChange] = device_change unless device_change.empty?
+
+          vm_reconfig_hardware('instance_uuid' => attributes[:instance_uuid], 'hardware_spec' => spec) unless spec.empty?
+        end
+
+        private
+
+        def update_vm_interfaces_specs(vm_mob_ref, fog_interfaces, datacenter)
+          vm_nics = vm_mob_ref.config.hardware.device.grep(RbVmomi::VIM::VirtualEthernetCard)
+          modified_nics = fog_interfaces.to_a.take(vm_nics.size)
+          new_nics = fog_interfaces.to_a.drop(vm_nics.size)
+
+          specs = []
+          vm_nics.zip(modified_nics).each do |vm_nic, fog_nic|
+            if fog_nic
+              # Update the attributes on the existing nic
+              backing = create_nic_backing(fog_nic, datacenter: datacenter)
+
+              if nic_backing_different?(vm_nic.backing, backing)
+                vm_nic.backing = backing
+                specs << { operation: :edit, device: vm_nic }
+              end
+            else
+              specs << {
+                operation: :remove,
+                device: vm_nic
+              }
+            end
+          end
+
+          specs.concat(new_nics.map { |nic| create_interface(nic, 0, :add, datacenter: datacenter) }) if new_nics.any?
+
+          specs
+        end
+
+        def update_vm_volumes_specs(vm_mob_ref, volumes)
+          vm_volumes = vm_mob_ref.config.hardware.device.grep(RbVmomi::VIM::VirtualDisk)
+          modified_volumes = volumes.to_a.take(vm_volumes.size)
+          new_volumes = volumes.to_a.drop(vm_volumes.size)
+
+          specs = []
+          vm_volumes.zip(modified_volumes).each do |vm_volume, fog_volume|
+            if fog_volume
+              update_volume_attributes(vm_volume, fog_volume)
+
+              specs << { operation: :edit, device: vm_volume }
+              next
+            end
+
+            specs << { operation: :remove, fileOperation: :destroy, device: vm_volume }
+          end
+
+          specs.concat(new_volumes.map { |volume| create_disk(volume) }) if new_volumes.any?
+
+          specs
+        end
+
+        def update_volume_attributes(vm_volume, fog_volume)
+          vm_volume.capacityInKB = fog_volume.size
+          vm_volume.backing.diskMode = fog_volume.mode
+          vm_volume.backing.thinProvisioned = fog_volume.thin
+        end
+
+        def nic_backing_different?(one, two)
+          return true if one.class != two.class
+
+          return true if one.is_a?(RbVmomi::VIM::VirtualEthernetCardDistributedVirtualPortBackingInfo) && (one.port.portgroupKey != two.port.portgroupKey || one.port.switchUuid != two.port.switchUuid)
+
+          return true if one.is_a?(RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo) && one.deviceName != two.deviceName && one.deviceType != twp.device
+
+          false
+        end
+      end
+
+      class Mock
+        def update_vm(_server)
+          # TODO: - currently useless and tests need to be re-though on a whole.
+          { 'task_state' => 'success' }
+        end
+      end
+    end
+  end
+end

--- a/tests/requests/compute/get_network_tests.rb
+++ b/tests/requests/compute/get_network_tests.rb
@@ -4,11 +4,12 @@ Shindo.tests('Fog::Compute[:vsphere] | get_network request', ['vsphere']) do
   compute = Fog::Compute[:vsphere]
 
   class DistributedVirtualPortgroup
-    attr_accessor :name, :dvs_name
+    attr_accessor :name, :dvs_name, :key
 
     def initialize(attrs)
       @name = attrs.fetch(:name)
       @dvs_name = attrs.fetch(:dvs_name)
+      @key = attrs.fetch(:key)
     end
 
     def config
@@ -17,9 +18,9 @@ Shindo.tests('Fog::Compute[:vsphere] | get_network request', ['vsphere']) do
   end
 
   fake_networks = [OpenStruct.new(name: 'non-dvs'),
-                   DistributedVirtualPortgroup.new(name: 'web1', dvs_name: 'dvs5'),
-                   DistributedVirtualPortgroup.new(name: 'web1', dvs_name: 'dvs11'),
-                   DistributedVirtualPortgroup.new(name: 'other', dvs_name: 'other')]
+                   DistributedVirtualPortgroup.new(name: 'web1', dvs_name: 'dvs5', key: '4001'),
+                   DistributedVirtualPortgroup.new(name: 'web1', dvs_name: 'dvs11', key: '4001'),
+                   DistributedVirtualPortgroup.new(name: 'other', dvs_name: 'other', key: '4001')]
 
   tests('#choose_finder should') do
     test('choose the network based on network name and dvs name') do

--- a/tests/requests/compute/update_vm_tests.rb
+++ b/tests/requests/compute/update_vm_tests.rb
@@ -1,0 +1,13 @@
+require 'ostruct'
+
+Shindo.tests('Fog::Compute[:vsphere] | update_vm request', 'vsphere') do
+  compute = Fog::Compute[:vsphere]
+  server = Fog::Compute::Vsphere::Server.new
+
+  tests('UPDATE vm | The return value should') do
+    response = compute.update_vm(server)
+    test('be a kind of Hash') { response.is_a? Hash }
+    test('should have a task_state key') { response.key? 'task_state' }
+    test('be a kind of Hash') { response.is_a? Hash }
+  end
+end


### PR DESCRIPTION
As part of https://github.com/theforeman/foreman/pull/5569

This adds the functionality to edit the network of an existing network and fixes some other issues with updating a vm. 

It also brings updating a vm into one request to the vsphere sdk reducing it from individual requests for each attribute.

#### TODO

- [x] Add tests
- [x] add mock implementation