### PR TITLE
add required datacenter param to all calls which may use get_vm_interface

### DIFF
--- a/lib/fog/vsphere/models/compute/interface.rb
+++ b/lib/fog/vsphere/models/compute/interface.rb
@@ -44,7 +44,7 @@ module Fog
         def destroy
           requires :server_id, :key, :type
 
-          service.destroy_vm_interface(server_id, key: key, type: type)
+          service.destroy_vm_interface(server_id, key: key, type: type, datacenter: server.datacenter)
         end
 
         def save

--- a/lib/fog/vsphere/models/compute/interfaces.rb
+++ b/lib/fog/vsphere/models/compute/interfaces.rb
@@ -29,7 +29,7 @@ module Fog
 
           case server
           when Fog::Compute::Vsphere::Server
-            interface = service.get_vm_interface(server.id, key: id, mac: id, name: id)
+            interface = service.get_vm_interface(server.id, key: id, mac: id, name: id, datacenter: server.datacenter)
           when Fog::Compute::Vsphere::Template
             interface = service.get_template_interfaces(server.id, key: id, mac: id, name: id)
           else

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -230,6 +230,7 @@ module Fog
 
         def update_interface(attrs)
           wait_for { !ready? } if interface_ready? attrs
+          attrs = attrs.merge(datacenter: datacenter) unless attrs.key? :datacenter
           service.update_vm_interface(id, attrs)
         end
 

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -230,7 +230,7 @@ module Fog
 
         def update_interface(attrs)
           wait_for { !ready? } if interface_ready? attrs
-          attrs = attrs.merge(datacenter: datacenter) unless attrs.key? :datacenter
+          attrs[:datacenter] = datacenter unless attrs.key? :datacenter
           service.update_vm_interface(id, attrs)
         end
 

--- a/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
@@ -13,7 +13,7 @@ module Fog
           raise ArgumentError, 'instance id is a required parameter' unless vmid
 
           interface = get_interface_from_options(vmid, options.merge(server_id: vmid))
-          vm_reconfig_hardware('instance_uuid' => vmid, 'hardware_spec' => { 'deviceChange' => [create_interface(interface, interface.key, :remove)] })
+          vm_reconfig_hardware('instance_uuid' => vmid, 'hardware_spec' => { 'deviceChange' => [create_interface(interface, interface.key, :remove, options)] })
         end
 
         def update_vm_interface(vmid, options = {})


### PR DESCRIPTION
Calling server.interfaces.get('mac_address') failed because datacenter is required
It could fail calling server.update_vm_interface because datacenter is required,
or calling interface.destroy