### PR TITLE
patch attribute[:datacenter] for create interface

### DIFF
--- a/lib/fog/vsphere/models/compute/interface.rb
+++ b/lib/fog/vsphere/models/compute/interface.rb
@@ -55,6 +55,7 @@ module Fog
           # and thus the highest :key value must correspond to the created interface.  Since this has an inherent race
           # condition we need to gate the saves.
           SAVE_MUTEX.synchronize do
+            attributes[:datacenter] = server.datacenter unless attributes.key?(:datacenter)
             data = service.add_vm_interface(server_id, attributes)
 
             if data['task_state'] == 'success'

--- a/lib/fog/vsphere/requests/compute/get_datacenter.rb
+++ b/lib/fog/vsphere/requests/compute/get_datacenter.rb
@@ -14,8 +14,9 @@ module Fog
           raw_datacenters.find { |d| d.name == name } || get_raw_datacenter(name)
         end
 
-        def get_raw_datacenter(name)
-          connection.serviceInstance.find_datacenter(name)
+        # @note RbVmomi takes path instead of name as argument to find datacenter
+        def get_raw_datacenter(path)
+          connection.serviceInstance.find_datacenter(path)
         end
       end
 


### PR DESCRIPTION
This patch is for working around create VM interface failure due to datacenter undefined. (undefined method `networkFolder' for nil:NilClass)