### PR TITLE
Expose extraConfig from user_data for vm_clone

### DIFF
--- a/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
+++ b/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
@@ -12,6 +12,7 @@ module Fog
           # identity expects an hash, REQUIRED
           # nicSettingMap expects an array
           # options expects an hash
+          # extraConfig expects a hash
 
           custom_spec['encryptionKey']    = user_data['encryptionKey'] if user_data.key?('encryptionKey')
           custom_spec['globalIPSettings'] = user_data['globalIPSettings'] if user_data.key?('globalIPSettings')
@@ -19,6 +20,7 @@ module Fog
           custom_spec['identity']         = { 'Sysprep' => { 'guiRunOnce' => { 'commandList' => user_data['runcmd'] } } } if user_data.key?('runcmd') && !user_data.key?('identity')
           custom_spec['nicSettingMap']    = user_data['nicSettingMap'] if user_data.key?('nicSettingMap')
           custom_spec['options']          = user_data['options'] if user_data.key?('options')
+          custom_spec['extraConfig']      = user_data['extraConfig'] if user_data.key?('extraConfig')
 
           # for backwards compatability
           # hostname expects a string, REQUIRED
@@ -50,6 +52,7 @@ module Fog
           custom_spec['identity']                     = user_data['identity'] if user_data.key?('identity')
           custom_spec['nicSettingMap']                = user_data['nicSettingMap'] if user_data.key?('nicSettingMap')
           custom_spec['options']                      = user_data['options'] if user_data.key?('options')
+          custom_spec['extraConfig']                  = user_data['extraConfig'] if user_data.key?('extraConfig')
           custom_spec['hostname']                     =  user_data['hostname'] if user_data.key?('hostname')
           custom_spec['ipsettings']                   =  { 'ip' => user_data['ip'] } if user_data.key?('ip')
           custom_spec['ipsettings']['subnetMask']     =  user_data['netmask'] if user_data.key?('netmask')


### PR DESCRIPTION
This is a pull request for the issue from #93 (Also see theforeman/foreman#6243)
Further information from https://projects.theforeman.org/issues/25457

    Two simple line changes allow for the extraConfig from userdata to be passed through to fog-vsphere vm_clone.
    This adds the option to pass through guestinfo network configuration for CoreOS VMs.
    With the use of Omaha or similar tools even building the ignition configuration and passing it to the VM on clone is an option.

    Without this change an additional tool has to be used to supply the guestinfo before the machine is started for the first time.