### PR TITLE
Fixes #188 - Update ruby string method to prevent traceback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-before_install: gem install bundler
+before_install: gem install bundler -v 1.17.3
 matrix:
   allow_failures:
     - rvm: jruby-head

--- a/lib/fog/vsphere/requests/compute/get_folder.rb
+++ b/lib/fog/vsphere/requests/compute/get_folder.rb
@@ -23,7 +23,7 @@ module Fog
                end
 
           valid_types = %w[vm network datastore host]
-          raise ArgumentError, "#{type} is unknown" if type.blank?
+          raise ArgumentError, "#{type} is unknown" if type.nil? || type.empty?
           raise "Invalid type (#{type}). Must be one of #{valid_types.join(', ')} " unless valid_types.include?(type.to_s)
           meth = "#{type}Folder"
           dc_root_folder = dc.send(meth)


### PR DESCRIPTION
@timogoebel can I get a review please? I tried to make a vm yesterday with with your gist and hit this, looking at the ruby docs .blank is not a method for a string anymore. After switching to .empty I was able to build with the script.