### PR TITLE
[WIP] Refs #197 - Encapsulate create_vm command

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,6 +39,7 @@ Lint/UselessAssignment:
     - 'lib/fog/vsphere/compute.rb'
     - 'lib/fog/vsphere/models/compute/interfaces.rb'
     - 'lib/fog/vsphere/models/compute/volumes.rb'
+    - 'lib/fog/vsphere/requests/compute/request.rb'
     - 'lib/fog/vsphere/requests/compute/create_rule.rb'
     - 'lib/fog/vsphere/requests/compute/create_vm.rb'
     - 'lib/fog/vsphere/requests/compute/get_interface_type.rb'
@@ -191,7 +192,7 @@ Style/RedundantSelf:
 Style/RegexpLiteral:
   Exclude:
     - 'lib/fog/vsphere/requests/compute/create_folder.rb'
-    - 'lib/fog/vsphere/requests/compute/get_folder.rb'
+    - 'lib/fog/vsphere/requests/compute/request.rb'
     - 'lib/fog/vsphere/requests/compute/list_resource_pools.rb'
 
 # Offense count: 1

--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -723,27 +723,11 @@ module Fog
         end
 
         def list_container_view(datacenter_obj_or_name, type, container_object = nil)
-          dc = if datacenter_obj_or_name.is_a?(String)
-                 find_raw_datacenter(datacenter_obj_or_name)
-               else
-                 datacenter_obj_or_name
-               end
+          shared_request.send('list_container_view', datacenter_obj_or_name, type, container_object)
+        end
 
-          container = if container_object
-                        dc.public_send(container_object)
-                      else
-                        dc
-                      end
-
-          container_view = connection.serviceContent.viewManager.CreateContainerView(
-            container: dc,
-            type: [type],
-            recursive: true
-          )
-
-          result = container_view.view
-          container_view.DestroyView
-          result
+        def shared_request
+          @shared_request ||= Fog::Vsphere::Requests::Compute::Request.new(connection)
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -1,291 +1,11 @@
+require 'fog/vsphere/requests/compute/request'
+
 module Fog
   module Vsphere
     class Compute
       class Real
         def create_vm(attributes = {})
-          # build up vm configuration
-
-          vm_cfg = {
-            name: attributes[:name],
-            annotation: attributes[:annotation],
-            guestId: attributes[:guest_id],
-            version: attributes[:hardware_version],
-            files: { vmPathName: vm_path_name(attributes) },
-            numCPUs: attributes[:cpus],
-            numCoresPerSocket: attributes[:corespersocket],
-            memoryMB: attributes[:memory_mb],
-            deviceChange: device_change(attributes),
-            extraConfig: extra_config(attributes)
-          }
-          vm_cfg[:cpuHotAddEnabled] = attributes[:cpuHotAddEnabled] if attributes.key?(:cpuHotAddEnabled)
-          vm_cfg[:memoryHotAddEnabled] = attributes[:memoryHotAddEnabled] if attributes.key?(:memoryHotAddEnabled)
-          vm_cfg[:firmware] = attributes[:firmware] if attributes.key?(:firmware)
-          vm_cfg[:bootOptions] = boot_options(attributes, vm_cfg) if attributes.key?(:boot_order) || attributes.key?(:boot_retry)
-          resource_pool = if attributes[:resource_pool] && attributes[:resource_pool] != 'Resources'
-                            get_raw_resource_pool(attributes[:resource_pool], attributes[:cluster], attributes[:datacenter])
-                          else
-                            get_raw_cluster(attributes[:cluster], attributes[:datacenter]).resourcePool
-                          end
-          vmFolder      = get_raw_vmfolder(attributes[:path], attributes[:datacenter])
-          host = if attributes.key?(:host)
-                   get_raw_host(attributes[:host], attributes[:cluster], attributes[:datacenter])
-                 end
-          # if any volume has a storage_pod set, we deploy the vm on a storage pod instead of the defined datastores
-          pod = get_storage_pod_from_volumes(attributes)
-          vm = if pod
-                 create_vm_on_storage_pod(pod, vm_cfg, vmFolder, resource_pool, attributes[:datacenter], host)
-               else
-                 create_vm_on_datastore(vm_cfg, vmFolder, resource_pool, host)
-               end
-          vm.config.instanceUuid
-        end
-
-        private
-
-        def create_vm_on_datastore(vm_cfg, vmFolder, resource_pool, host = nil)
-          vm = vmFolder.CreateVM_Task(config: vm_cfg, pool: resource_pool, host: host).wait_for_completion
-        end
-
-        def create_vm_on_storage_pod(storage_pod, vm_cfg, vmFolder, resource_pool, datacenter, host = nil)
-          pod_spec = RbVmomi::VIM::StorageDrsPodSelectionSpec.new(
-            storagePod: get_raw_storage_pod(storage_pod, datacenter)
-          )
-          storage_spec = RbVmomi::VIM::StoragePlacementSpec.new(
-            type: 'create',
-            folder: vmFolder,
-            resourcePool: resource_pool,
-            podSelectionSpec: pod_spec,
-            configSpec: vm_cfg,
-            host: host
-          )
-          srm = connection.serviceContent.storageResourceManager
-          result = srm.RecommendDatastores(storageSpec: storage_spec)
-
-          # if result array contains recommendation, we can apply it
-          if key = result.recommendations.first.key
-            result = srm.ApplyStorageDrsRecommendation_Task(key: [key]).wait_for_completion
-            vm = result.vm
-          else
-            raise 'Could not create vm on storage pod, did not get a storage recommendation'
-          end
-          vm
-        end
-
-        # check if a storage pool is set on any of the volumes and return the first result found or nil
-        # return early if vsphere revision is lower than 5 as this is not supported
-        def get_storage_pod_from_volumes(attributes)
-          return unless @vsphere_rev.to_f >= 5
-          volume = attributes[:volumes].detect { |volume| !(volume.storage_pod.nil? || volume.storage_pod.empty?) }
-          volume.storage_pod if volume
-        end
-
-        # this methods defines where the vm config files would be located,
-        # by default we prefer to keep it at the same place the (first) vmdk is located
-        # if we deploy the vm on a storage pool, we have to return an empty string
-        def vm_path_name(attributes)
-          return '' if get_storage_pod_from_volumes(attributes)
-          datastore = attributes[:volumes].first.datastore unless attributes[:volumes].empty?
-          datastore ||= 'datastore1'
-          "[#{datastore}]"
-        end
-
-        def device_change(attributes)
-          devices = []
-          if (nics = attributes[:interfaces])
-            devices << nics.map { |nic| create_interface(nic, nics.index(nic), :add, attributes) }
-          end
-
-          if (scsi_controllers = (attributes[:scsi_controllers] || attributes['scsi_controller']))
-            devices << scsi_controllers.each_with_index.map { |controller, index| create_controller(controller, index) }
-          end
-
-          if (disks = attributes[:volumes])
-            devices << disks.map { |disk| create_disk(disk, :add, storage_pod: get_storage_pod_from_volumes(attributes)) }
-          end
-
-          if (cdroms = attributes[:cdroms])
-            devices << cdroms.map { |cdrom| create_cdrom(cdrom, cdroms.index(cdrom)) }
-          end
-          devices.flatten
-        end
-
-        def boot_options(attributes, vm_cfg)
-          # NOTE: you must be using vsphere_rev 5.0 or greater to set boot_order
-          # e.g. Fog::Compute.new(provider: "vsphere", vsphere_rev: "5.5", etc)
-          options = {}
-          if (@vsphere_rev.to_f >= 5) && attributes[:boot_order]
-            options[:bootOrder] = boot_order(attributes, vm_cfg)
-          end
-
-          # Set attributes[:boot_retry] to a delay in miliseconds to enable boot retries
-          if attributes[:boot_retry]
-            options[:bootRetryEnabled] = true
-            options[:bootRetryDelay]   = attributes[:boot_retry]
-          end
-
-          options.empty? ? nil : RbVmomi::VIM::VirtualMachineBootOptions.new(options)
-        end
-
-        def boot_order(attributes, vm_cfg)
-          # attributes[:boot_order] may be an array like this ['network', 'disk']
-          # stating, that we want to prefer network boots over disk boots
-          boot_order = []
-          attributes[:boot_order].each do |boot_device|
-            case boot_device
-            when 'network'
-              if nics = attributes[:interfaces]
-                # key is based on 4000 + the interface index
-                # we allow booting from all network interfaces, the first interface has the highest priority
-                nics.each do |nic|
-                  boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableEthernetDevice.new(
-                    deviceKey: 4000 + nics.index(nic)
-                  )
-                end
-              end
-            when 'disk'
-              disks = vm_cfg[:deviceChange].map { |dev| dev[:device] }.select { |dev| dev.is_a? RbVmomi::VIM::VirtualDisk }
-              disks.each do |disk|
-                # we allow booting from all harddisks, the first disk has the highest priority
-                boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableDiskDevice.new(
-                  deviceKey: disk.key
-                )
-              end
-            when 'cdrom'
-              boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableCdromDevice.new
-            when 'floppy'
-              boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableFloppyDevice.new
-            else
-              raise "failed to create boot device because \"#{boot_device}\" is unknown"
-            end
-          end
-          boot_order
-        end
-
-        def create_nic_backing(nic, attributes)
-          raw_network = get_raw_network(nic.network, attributes[:datacenter], if nic.virtualswitch then nic.virtualswitch end)
-
-          if raw_network.is_a? RbVmomi::VIM::DistributedVirtualPortgroup
-            RbVmomi::VIM.VirtualEthernetCardDistributedVirtualPortBackingInfo(
-              port: RbVmomi::VIM.DistributedVirtualSwitchPortConnection(
-                portgroupKey: raw_network.key,
-                switchUuid: raw_network.config.distributedVirtualSwitch.uuid
-              )
-            )
-          elsif raw_network.is_a? RbVmomi::VIM::OpaqueNetwork
-            RbVmomi::VIM.VirtualEthernetCardOpaqueNetworkBackingInfo(
-              opaqueNetworkType: raw_network.summary.opaqueNetworkType,
-              opaqueNetworkId: raw_network.summary.opaqueNetworkId
-            )
-
-          else
-            RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(deviceName: raw_network.name)
-          end
-        end
-
-        def create_interface(nic, index = 0, operation = :add, attributes = {})
-          {
-            operation: operation,
-            device: nic.type.new(
-              key: index,
-              deviceInfo:                 {
-                label: nic.name,
-                summary: nic.summary
-              },
-              backing: create_nic_backing(nic, attributes),
-              addressType: 'generated'
-            )
-          }
-        end
-
-        def create_controller(controller = nil, index = 0)
-          options = if controller
-                      controller_default_options.merge(controller.attributes)
-                    else
-                      controller_default_options
-                  end
-          controller_class = if options[:type].is_a? String
-                               Fog::Vsphere.class_from_string options[:type], 'RbVmomi::VIM'
-                             else
-                               options[:type]
-                           end
-          {
-            operation: options[:operation],
-            device: controller_class.new(key: options[:key] || (1000 + index),
-                                         busNumber: options[:bus_id] || index,
-                                         sharedBus: controller_get_shared_from_options(options))
-          }
-        end
-
-        def controller_default_options
-          { operation: :add, type: RbVmomi::VIM.VirtualLsiLogicController.class, shared: false }
-        end
-
-        def controller_get_shared_from_options(options)
-          if (options.key?(:shared) && (options[:shared] == false)) || (!options.key? :shared)
-            :noSharing
-          elsif options[:shared] == true
-            :virtualSharing
-          elsif options[:shared].is_a? String
-            options[:shared]
-          else
-            :noSharing
-          end
-        end
-
-        def create_disk(disk, operation = :add, options = {})
-          # If we deploy the vm on a storage pod, datastore has to be an empty string
-          datastore = if options[:storage_pod]
-                        ''
-                      else
-                        "[#{disk.datastore}]"
-                      end
-
-          disk.set_unit_number
-          disk.set_key
-
-          payload = {
-            operation: operation,
-            device: RbVmomi::VIM.VirtualDisk(
-              key: disk.key,
-              backing: RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
-                fileName: options[:filename] || datastore,
-                diskMode: disk.mode.to_sym,
-                thinProvisioned: disk.thin
-              ),
-              controllerKey: disk.controller_key,
-              unitNumber: disk.unit_number,
-              capacityInKB: disk.size
-            )
-          }
-          file_operation = options[:file_operation] || (:create if operation == :add)
-          payload[:fileOperation] = file_operation if file_operation
-
-          if operation == :add && disk.thin == 'false' && disk.eager_zero == 'true'
-            payload[:device][:backing][:eagerlyScrub] = disk.eager_zero
-          end
-
-          payload
-        end
-
-        def create_cdrom(cdrom, index = 0, operation = :add, controller_key = 200)
-          {
-            operation: operation,
-            device: RbVmomi::VIM.VirtualCdrom(
-              key: cdrom.key || index,
-              backing: RbVmomi::VIM::VirtualCdromRemoteAtapiBackingInfo(deviceName: ''),
-              controllerKey: controller_key,
-              connectable: RbVmomi::VIM::VirtualDeviceConnectInfo(
-                startConnected: false,
-                connected: false,
-                allowGuestControl: true
-              )
-            )
-          }
-        end
-
-        def extra_config(attributes)
-          extra_config = attributes[:extra_config] || { 'bios.bootOrder' => 'ethernet0' }
-          extra_config.map { |k, v| { key: k, value: v.to_s } }
+          Requests::Compute::CreateVm.new(connection).run(attributes)
         end
       end
 
@@ -323,6 +43,294 @@ module Fog
               }
             }
           }
+        end
+      end
+    end
+
+    module Requests
+      module Compute
+        class CreateVm < Request
+          def run(attributes = {})
+            # build up vm configuration
+            vm_cfg = {
+              name: attributes[:name],
+              annotation: attributes[:annotation],
+              guestId: attributes[:guest_id],
+              version: attributes[:hardware_version],
+              files: { vmPathName: vm_path_name(attributes) },
+              numCPUs: attributes[:cpus],
+              numCoresPerSocket: attributes[:corespersocket],
+              memoryMB: attributes[:memory_mb],
+              deviceChange: device_change(attributes),
+              extraConfig: extra_config(attributes)
+            }
+            vm_cfg[:cpuHotAddEnabled] = attributes[:cpuHotAddEnabled] if attributes.key?(:cpuHotAddEnabled)
+            vm_cfg[:memoryHotAddEnabled] = attributes[:memoryHotAddEnabled] if attributes.key?(:memoryHotAddEnabled)
+            vm_cfg[:firmware] = attributes[:firmware] if attributes.key?(:firmware)
+            vm_cfg[:bootOptions] = boot_options(attributes, vm_cfg) if attributes.key?(:boot_order) || attributes.key?(:boot_retry)
+            resource_pool = if attributes[:resource_pool] && attributes[:resource_pool] != 'Resources'
+                              get_raw_resource_pool(attributes[:resource_pool], attributes[:cluster], attributes[:datacenter])
+                            else
+                              get_raw_cluster(attributes[:cluster], attributes[:datacenter]).resourcePool
+                            end
+            vmFolder      = get_raw_vmfolder(attributes[:path], attributes[:datacenter])
+            host = if attributes.key?(:host)
+                     get_raw_host(attributes[:host], attributes[:cluster], attributes[:datacenter])
+                   end
+            # if any volume has a storage_pod set, we deploy the vm on a storage pod instead of the defined datastores
+            pod = get_storage_pod_from_volumes(attributes)
+            vm = if pod
+                   create_vm_on_storage_pod(pod, vm_cfg, vmFolder, resource_pool, attributes[:datacenter], host)
+                 else
+                   create_vm_on_datastore(vm_cfg, vmFolder, resource_pool, host)
+                 end
+            vm.config.instanceUuid
+          end
+
+          def create_vm_on_datastore(vm_cfg, vmFolder, resource_pool, host = nil)
+            vm = vmFolder.CreateVM_Task(config: vm_cfg, pool: resource_pool, host: host).wait_for_completion
+          end
+
+          def create_vm_on_storage_pod(storage_pod, vm_cfg, vmFolder, resource_pool, datacenter, host = nil)
+            pod_spec = RbVmomi::VIM::StorageDrsPodSelectionSpec.new(
+              storagePod: get_raw_storage_pod(storage_pod, datacenter)
+            )
+            storage_spec = RbVmomi::VIM::StoragePlacementSpec.new(
+              type: 'create',
+              folder: vmFolder,
+              resourcePool: resource_pool,
+              podSelectionSpec: pod_spec,
+              configSpec: vm_cfg,
+              host: host
+            )
+            srm = connection.serviceContent.storageResourceManager
+            result = srm.RecommendDatastores(storageSpec: storage_spec)
+
+            # if result array contains recommendation, we can apply it
+            if key = result.recommendations.first.key
+              result = srm.ApplyStorageDrsRecommendation_Task(key: [key]).wait_for_completion
+              vm = result.vm
+            else
+              raise 'Could not create vm on storage pod, did not get a storage recommendation'
+            end
+            vm
+          end
+
+          # check if a storage pool is set on any of the volumes and return the first result found or nil
+          # return early if vsphere revision is lower than 5 as this is not supported
+          def get_storage_pod_from_volumes(attributes)
+            return unless @vsphere_rev.to_f >= 5
+            volume = attributes[:volumes].detect { |volume| !(volume.storage_pod.nil? || volume.storage_pod.empty?) }
+            volume.storage_pod if volume
+          end
+
+          # this methods defines where the vm config files would be located,
+          # by default we prefer to keep it at the same place the (first) vmdk is located
+          # if we deploy the vm on a storage pool, we have to return an empty string
+          def vm_path_name(attributes)
+            return '' if get_storage_pod_from_volumes(attributes)
+            datastore = attributes[:volumes].first.datastore unless attributes[:volumes].empty?
+            datastore ||= 'datastore1'
+            "[#{datastore}]"
+          end
+
+          def device_change(attributes)
+            devices = []
+            if (nics = attributes[:interfaces])
+              devices << nics.map { |nic| create_interface(nic, nics.index(nic), :add, attributes) }
+            end
+
+            if (scsi_controllers = (attributes[:scsi_controllers] || attributes['scsi_controller']))
+              devices << scsi_controllers.each_with_index.map { |controller, index| create_controller(controller, index) }
+            end
+
+            if (disks = attributes[:volumes])
+              devices << disks.map { |disk| create_disk(disk, :add, storage_pod: get_storage_pod_from_volumes(attributes)) }
+            end
+
+            if (cdroms = attributes[:cdroms])
+              devices << cdroms.map { |cdrom| create_cdrom(cdrom, cdroms.index(cdrom)) }
+            end
+            devices.flatten
+          end
+
+          def boot_options(attributes, vm_cfg)
+            # NOTE: you must be using vsphere_rev 5.0 or greater to set boot_order
+            # e.g. Fog::Compute.new(provider: "vsphere", vsphere_rev: "5.5", etc)
+            options = {}
+            if (@vsphere_rev.to_f >= 5) && attributes[:boot_order]
+              options[:bootOrder] = boot_order(attributes, vm_cfg)
+            end
+
+            # Set attributes[:boot_retry] to a delay in miliseconds to enable boot retries
+            if attributes[:boot_retry]
+              options[:bootRetryEnabled] = true
+              options[:bootRetryDelay]   = attributes[:boot_retry]
+            end
+
+            options.empty? ? nil : RbVmomi::VIM::VirtualMachineBootOptions.new(options)
+          end
+
+          def boot_order(attributes, vm_cfg)
+            # attributes[:boot_order] may be an array like this ['network', 'disk']
+            # stating, that we want to prefer network boots over disk boots
+            boot_order = []
+            attributes[:boot_order].each do |boot_device|
+              case boot_device
+              when 'network'
+                if nics = attributes[:interfaces]
+                  # key is based on 4000 + the interface index
+                  # we allow booting from all network interfaces, the first interface has the highest priority
+                  nics.each do |nic|
+                    boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableEthernetDevice.new(
+                      deviceKey: 4000 + nics.index(nic)
+                    )
+                  end
+                end
+              when 'disk'
+                disks = vm_cfg[:deviceChange].map { |dev| dev[:device] }.select { |dev| dev.is_a? RbVmomi::VIM::VirtualDisk }
+                disks.each do |disk|
+                  # we allow booting from all harddisks, the first disk has the highest priority
+                  boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableDiskDevice.new(
+                    deviceKey: disk.key
+                  )
+                end
+              when 'cdrom'
+                boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableCdromDevice.new
+              when 'floppy'
+                boot_order << RbVmomi::VIM::VirtualMachineBootOptionsBootableFloppyDevice.new
+              else
+                raise "failed to create boot device because \"#{boot_device}\" is unknown"
+              end
+            end
+            boot_order
+          end
+
+          def create_nic_backing(nic, attributes)
+            raw_network = get_raw_network(nic.network, attributes[:datacenter], if nic.virtualswitch then nic.virtualswitch end)
+
+            if raw_network.is_a? RbVmomi::VIM::DistributedVirtualPortgroup
+              RbVmomi::VIM.VirtualEthernetCardDistributedVirtualPortBackingInfo(
+                port: RbVmomi::VIM.DistributedVirtualSwitchPortConnection(
+                  portgroupKey: raw_network.key,
+                  switchUuid: raw_network.config.distributedVirtualSwitch.uuid
+                )
+              )
+            elsif raw_network.is_a? RbVmomi::VIM::OpaqueNetwork
+              RbVmomi::VIM.VirtualEthernetCardOpaqueNetworkBackingInfo(
+                opaqueNetworkType: raw_network.summary.opaqueNetworkType,
+                opaqueNetworkId: raw_network.summary.opaqueNetworkId
+              )
+            else
+              RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(deviceName: raw_network.name)
+            end
+          end
+
+          def create_interface(nic, index = 0, operation = :add, attributes = {})
+            {
+              operation: operation,
+              device: nic.type.new(
+                key: index,
+                deviceInfo:                 {
+                  label: nic.name,
+                  summary: nic.summary
+                },
+                backing: create_nic_backing(nic, attributes),
+                addressType: 'generated'
+              )
+            }
+          end
+
+          def create_controller(controller = nil, index = 0)
+            options = if controller
+                        controller_default_options.merge(controller.attributes)
+                      else
+                        controller_default_options
+                    end
+            controller_class = if options[:type].is_a? String
+                                 Fog::Vsphere.class_from_string options[:type], 'RbVmomi::VIM'
+                               else
+                                 options[:type]
+                             end
+            {
+              operation: options[:operation],
+              device: controller_class.new(key: options[:key] || (1000 + index),
+                                           busNumber: options[:bus_id] || index,
+                                           sharedBus: controller_get_shared_from_options(options))
+            }
+          end
+
+          def controller_default_options
+            { operation: :add, type: RbVmomi::VIM.VirtualLsiLogicController.class, shared: false }
+          end
+
+          def controller_get_shared_from_options(options)
+            if (options.key?(:shared) && (options[:shared] == false)) || (!options.key? :shared)
+              :noSharing
+            elsif options[:shared] == true
+              :virtualSharing
+            elsif options[:shared].is_a? String
+              options[:shared]
+            else
+              :noSharing
+            end
+          end
+
+          def create_disk(disk, operation = :add, options = {})
+            # If we deploy the vm on a storage pod, datastore has to be an empty string
+            datastore = if options[:storage_pod]
+                          ''
+                        else
+                          "[#{disk.datastore}]"
+                        end
+
+            disk.set_unit_number
+            disk.set_key
+
+            payload = {
+              operation: operation,
+              device: RbVmomi::VIM.VirtualDisk(
+                key: disk.key,
+                backing: RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
+                  fileName: options[:filename] || datastore,
+                  diskMode: disk.mode.to_sym,
+                  thinProvisioned: disk.thin
+                ),
+                controllerKey: disk.controller_key,
+                unitNumber: disk.unit_number,
+                capacityInKB: disk.size
+              )
+            }
+            file_operation = options[:file_operation] || (:create if operation == :add)
+            payload[:fileOperation] = file_operation if file_operation
+
+            if operation == :add && disk.thin == 'false' && disk.eager_zero == 'true'
+              payload[:device][:backing][:eagerlyScrub] = disk.eager_zero
+            end
+
+            payload
+          end
+
+          def create_cdrom(cdrom, index = 0, operation = :add, controller_key = 200)
+            {
+              operation: operation,
+              device: RbVmomi::VIM.VirtualCdrom(
+                key: cdrom.key || index,
+                backing: RbVmomi::VIM::VirtualCdromRemoteAtapiBackingInfo(deviceName: ''),
+                controllerKey: controller_key,
+                connectable: RbVmomi::VIM::VirtualDeviceConnectInfo(
+                  startConnected: false,
+                  connected: false,
+                  allowGuestControl: true
+                )
+              )
+            }
+          end
+
+          def extra_config(attributes)
+            extra_config = attributes[:extra_config] || { 'bios.bootOrder' => 'ethernet0' }
+            extra_config.map { |k, v| { key: k, value: v.to_s } }
+          end
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/get_cluster.rb
+++ b/lib/fog/vsphere/requests/compute/get_cluster.rb
@@ -11,12 +11,7 @@ module Fog
         protected
 
         def get_raw_cluster(name, datacenter_name_or_obj)
-          dc = if datacenter_name_or_obj.is_a?(String)
-                 find_raw_datacenter(datacenter_name_or_obj)
-               else
-                 datacenter_name_or_obj
-               end
-          dc.find_compute_resource(name)
+          shared_request.get_raw_cluster(name, datacenter_name_or_obj)
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/get_datacenter.rb
+++ b/lib/fog/vsphere/requests/compute/get_datacenter.rb
@@ -11,7 +11,7 @@ module Fog
         protected
 
         def find_raw_datacenter(name)
-          raw_datacenters.find { |d| d.name == name } || get_raw_datacenter(name)
+          shared_request.find_raw_datacenter(name)
         end
 
         # @note RbVmomi takes path instead of name as argument to find datacenter

--- a/lib/fog/vsphere/requests/compute/get_datastore.rb
+++ b/lib/fog/vsphere/requests/compute/get_datastore.rb
@@ -11,11 +11,7 @@ module Fog
         protected
 
         def get_raw_datastore(name, datacenter_name)
-          get_raw_datastores(datacenter_name).detect { |ds| ds.name == name }
-        end
-
-        def get_raw_datastores(datacenter_name)
-          list_container_view(datacenter_name, 'Datastore', :datastoreFolder)
+          shared_request.get_raw_datastore(name, datacenter_name)
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/get_folder.rb
+++ b/lib/fog/vsphere/requests/compute/get_folder.rb
@@ -13,40 +13,11 @@ module Fog
         protected
 
         def get_raw_folder(path, datacenter_name_or_obj, type)
-          # The required path syntax - 'topfolder/subfolder
-
-          # Clean up path to be relative since we're providing datacenter name
-          dc = if datacenter_name_or_obj.is_a?(String)
-                 find_raw_datacenter(datacenter_name_or_obj)
-               else
-                 datacenter_name_or_obj
-               end
-
-          valid_types = %w[vm network datastore host]
-          raise ArgumentError, "#{type} is unknown" if type.nil? || type.empty?
-          raise "Invalid type (#{type}). Must be one of #{valid_types.join(', ')} " unless valid_types.include?(type.to_s)
-          meth = "#{type}Folder"
-          dc_root_folder = dc.send(meth)
-
-          # Filter the root path for this datacenter not to be used."
-          dc_root_folder_path = dc_root_folder.path.map { |_, name| name }.join('/')
-          paths = path.sub(/^\/?#{Regexp.quote(dc_root_folder_path)}\/?/, '').split('/')
-
-          return dc_root_folder if paths.empty?
-          # Walk the tree resetting the folder pointer as we go
-          paths.reduce(dc_root_folder) do |last_returned_folder, sub_folder|
-            # JJM VIM::Folder#find appears to be quite efficient as it uses the
-            # searchIndex It certainly appears to be faster than
-            # VIM::Folder#inventory since that returns _all_ managed objects of
-            # a certain type _and_ their properties.
-            sub = last_returned_folder.find(sub_folder, RbVmomi::VIM::Folder)
-            raise Fog::Vsphere::Compute::NotFound, "Could not descend into #{sub_folder}.  Please check your path. #{path}" unless sub
-            sub
-          end
+          shared_request.get_raw_folder(path, datacenter_name_or_obj, type)
         end
 
         def get_raw_vmfolder(path, datacenter_name)
-          get_raw_folder(path, datacenter_name, 'vm')
+          shared_request.get_raw_folder(path, datacenter_name, 'vm')
         end
 
         def folder_attributes(folder, datacenter_name)

--- a/lib/fog/vsphere/requests/compute/get_host.rb
+++ b/lib/fog/vsphere/requests/compute/get_host.rb
@@ -9,9 +9,7 @@ module Fog
         protected
 
         def get_raw_host(name, cluster_name, datacenter_name)
-          cluster = get_raw_cluster(cluster_name, datacenter_name)
-          cluster.host.find { |host| host.name == name } ||
-            raise(Fog::Vsphere::Compute::NotFound, "no such host #{name}")
+          shared_request.get_raw_host(name, cluster_name, datacenter_name)
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -11,39 +11,7 @@ module Fog
         protected
 
         def get_raw_network(ref_or_name, datacenter_name, distributedswitch = nil)
-          finder = choose_finder(ref_or_name, distributedswitch)
-          get_all_raw_networks(datacenter_name).find { |n| finder.call(n) }
-        end
-      end
-
-      module Shared
-        protected
-
-        def get_all_raw_networks(datacenter_name)
-          list_container_view(datacenter_name, 'Network', :networkFolder)
-        end
-
-        def choose_finder(ref_or_name, distributedswitch)
-          case distributedswitch
-          when String
-            # only the one will do
-            proc do |n|
-              n._ref == ref_or_name || (
-                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name) &&
-                (n.config.distributedVirtualSwitch.name == distributedswitch)
-              )
-            end
-          when :dvs
-            # the first distributed virtual switch will do - selected by network - gives control to vsphere
-            proc do |n|
-              n._ref == ref_or_name || (
-                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name)
-              )
-            end
-          else
-            # the first matching network will do, seems like the non-distributed networks come first
-            proc { |n| n._ref == ref_or_name || n.name == ref_or_name || (n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && n.key == ref_or_name) }
-          end
+          shared_request.get_raw_network(ref_or_name, datacenter_name, distributedswitch)
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/get_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/get_resource_pool.rb
@@ -11,9 +11,7 @@ module Fog
         protected
 
         def get_raw_resource_pool(name, cluster_name, datacenter_name)
-          dc      = find_raw_datacenter(datacenter_name)
-          cluster = dc.find_compute_resource(cluster_name)
-          name.nil? ? cluster.resourcePool : cluster.resourcePool.traverse(name)
+          shared_request.get_raw_resource_pool(name, cluster_name, datacenter_name)
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/get_storage_pod.rb
+++ b/lib/fog/vsphere/requests/compute/get_storage_pod.rb
@@ -11,11 +11,7 @@ module Fog
         protected
 
         def get_raw_storage_pod(name, datacenter_name)
-          raw_storage_pods(datacenter_name).detect { |pod| pod.name == name }
-        end
-
-        def raw_storage_pods(datacenter_name)
-          list_container_view(datacenter_name, 'StoragePod')
+          shared_request.get_raw_storage_pod(name, datacenter_name)
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/list_datacenters.rb
+++ b/lib/fog/vsphere/requests/compute/list_datacenters.rb
@@ -24,18 +24,7 @@ module Fog
         end
 
         def raw_datacenters(folder = nil)
-          folder ||= connection.rootFolder
-          @raw_datacenters ||= get_raw_datacenters_from_folder folder
-        end
-
-        def get_raw_datacenters_from_folder(folder = nil)
-          folder.childEntity.map do |childE|
-            if childE.is_a? RbVmomi::VIM::Datacenter
-              childE
-            elsif childE.is_a? RbVmomi::VIM::Folder
-              get_raw_datacenters_from_folder childE
-            end
-          end.flatten
+          shared_request.raw_datacenters(folder)
         end
 
         def find_datacenters(name = nil)

--- a/lib/fog/vsphere/requests/compute/request.rb
+++ b/lib/fog/vsphere/requests/compute/request.rb
@@ -1,0 +1,170 @@
+require 'fog/vsphere/requests/request'
+
+module Fog
+  module Vsphere
+    module Requests
+      module Compute
+        class Request < Fog::Vsphere::Requests::Request
+          def raw_datacenters(folder = nil)
+            folder ||= connection.rootFolder
+            @raw_datacenters ||= get_raw_datacenters_from_folder folder
+          end
+
+          def find_raw_datacenter(name)
+            raw_datacenters.find { |d| d.name == name } || get_raw_datacenter(name)
+          end
+
+          def get_raw_cluster(name, datacenter_name_or_obj)
+            dc = if datacenter_name_or_obj.is_a?(String)
+                   find_raw_datacenter(datacenter_name_or_obj)
+                 else
+                   datacenter_name_or_obj
+                 end
+            dc.find_compute_resource(name)
+          end
+
+          def get_raw_host(name, cluster_name, datacenter_name)
+            cluster = get_raw_cluster(cluster_name, datacenter_name)
+            cluster.host.find { |host| host.name == name } ||
+              raise(Fog::Vsphere::Compute::NotFound, "no such host #{name}")
+          end
+
+          def get_raw_resource_pool(name, cluster_name, datacenter_name)
+            dc      = find_raw_datacenter(datacenter_name)
+            cluster = dc.find_compute_resource(cluster_name)
+            name.nil? ? cluster.resourcePool : cluster.resourcePool.traverse(name)
+          end
+
+          # Folders
+
+          def get_raw_folder(path, datacenter_name_or_obj, type)
+            # The required path syntax - 'topfolder/subfolder
+
+            # Clean up path to be relative since we're providing datacenter name
+            dc = if datacenter_name_or_obj.is_a?(String)
+                   find_raw_datacenter(datacenter_name_or_obj)
+                 else
+                   datacenter_name_or_obj
+                 end
+
+            valid_types = %w[vm network datastore host]
+            raise ArgumentError, "#{type} is unknown" if type.nil? || type.empty?
+            raise "Invalid type (#{type}). Must be one of #{valid_types.join(', ')} " unless valid_types.include?(type.to_s)
+            meth = "#{type}Folder"
+            dc_root_folder = dc.send(meth)
+
+            # Filter the root path for this datacenter not to be used."
+            dc_root_folder_path = dc_root_folder.path.map { |_, name| name }.join('/')
+            paths = path.sub(/^\/?#{Regexp.quote(dc_root_folder_path)}\/?/, '').split('/')
+
+            return dc_root_folder if paths.empty?
+            # Walk the tree resetting the folder pointer as we go
+            paths.reduce(dc_root_folder) do |last_returned_folder, sub_folder|
+              # JJM VIM::Folder#find appears to be quite efficient as it uses the
+              # searchIndex It certainly appears to be faster than
+              # VIM::Folder#inventory since that returns _all_ managed objects of
+              # a certain type _and_ their properties.
+              sub = last_returned_folder.find(sub_folder, RbVmomi::VIM::Folder)
+              raise Fog::Vsphere::Compute::NotFound, "Could not descend into #{sub_folder}.  Please check your path. #{path}" unless sub
+              sub
+            end
+          end
+
+          def get_raw_vmfolder(path, datacenter_name)
+            get_raw_folder(path, datacenter_name, 'vm')
+          end
+
+          # Datastores
+
+          def get_raw_datastore(name, datacenter_name)
+            get_raw_datastores(datacenter_name).detect { |ds| ds.name == name }
+          end
+
+          def get_raw_datastores(datacenter_name)
+            list_container_view(datacenter_name, 'Datastore', :datastoreFolder)
+          end
+
+          # Storage pods
+
+          def raw_storage_pods(datacenter_name)
+            list_container_view(datacenter_name, 'StoragePod')
+          end
+
+          def get_raw_storage_pod(name, datacenter_name)
+            raw_storage_pods(datacenter_name).detect { |pod| pod.name == name }
+          end
+
+          # Networks
+
+          def get_raw_network(ref_or_name, datacenter_name, distributedswitch = nil)
+            finder = choose_network_finder(ref_or_name, distributedswitch)
+            get_all_raw_networks(datacenter_name).find { |n| finder.call(n) }
+          end
+
+          def get_all_raw_networks(datacenter_name)
+            list_container_view(datacenter_name, 'Network', :networkFolder)
+          end
+
+          def choose_network_finder(ref_or_name, distributedswitch)
+            case distributedswitch
+            when String
+              # only the one will do
+              proc do |n|
+                n._ref == ref_or_name || (
+                  n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name) &&
+                  (n.config.distributedVirtualSwitch.name == distributedswitch)
+                )
+              end
+            when :dvs
+              # the first distributed virtual switch will do - selected by network - gives control to vsphere
+              proc do |n|
+                n._ref == ref_or_name || (
+                  n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name)
+                )
+              end
+            else
+              # the first matching network will do, seems like the non-distributed networks come first
+              proc { |n| n._ref == ref_or_name || n.name == ref_or_name || (n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && n.key == ref_or_name) }
+            end
+          end
+
+          private
+
+          def get_raw_datacenters_from_folder(folder = nil)
+            folder.childEntity.map do |child|
+              if child.is_a? RbVmomi::VIM::Datacenter
+                child
+              elsif child.is_a? RbVmomi::VIM::Folder
+                get_raw_datacenters_from_folder child
+              end
+            end.flatten
+          end
+
+          def list_container_view(datacenter_obj_or_name, type, container_object = nil)
+            dc = if datacenter_obj_or_name.is_a?(String)
+                   find_raw_datacenter(datacenter_obj_or_name)
+                 else
+                   datacenter_obj_or_name
+                 end
+
+            container = if container_object
+                          dc.public_send(container_object)
+                        else
+                          dc
+                        end
+
+            container_view = connection.serviceContent.viewManager.CreateContainerView(
+              container: dc,
+              type: [type],
+              recursive: true
+            )
+
+            result = container_view.view
+            container_view.DestroyView
+            result
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/request.rb
+++ b/lib/fog/vsphere/requests/request.rb
@@ -1,0 +1,17 @@
+module Fog
+  module Vsphere
+    module Requests
+      class Request
+        attr_accessor :connection
+
+        def initialize(connection)
+          @connection = connection
+        end
+
+        def run
+          raise Fog::Errors::NotImplemented, "The commands #{self.class.name}#run method is not implemented."
+        end
+      end
+    end
+  end
+end

--- a/tests/requests/compute/request_tests.rb
+++ b/tests/requests/compute/request_tests.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
-Shindo.tests('Fog::Compute[:vsphere] | get_network request', ['vsphere']) do
-  compute = Fog::Compute[:vsphere]
+Shindo.tests('Fog::Vsphere::Requests::Compute::Request | shared request', ['vsphere']) do
+  request = Fog::Vsphere::Requests::Compute::Request.new(nil)
 
   before do
     mocha_setup
@@ -30,24 +30,24 @@ Shindo.tests('Fog::Compute[:vsphere] | get_network request', ['vsphere']) do
     ]
   end
 
-  tests('#choose_finder should') do
+  tests('#choose_network_finder should') do
     test('choose the network based on network name and dvs name') do
-      finder = compute.send(:choose_finder, 'web1', 'dvs11')
+      finder = request.send(:choose_network_finder, 'web1', 'dvs11')
       found_network = fake_networks.find { |n| finder.call(n) }
       found_network.name == 'web1' && found_network.dvs_name == 'dvs11'
     end
     test('choose the network based on network name and any dvs') do
-      finder = compute.send(:choose_finder, 'web1', :dvs)
+      finder = request.send(:choose_network_finder, 'web1', :dvs)
       found_network = fake_networks.find { |n| finder.call(n) }
       found_network.name == 'web1' && found_network.dvs_name == 'dvs5'
     end
     test('choose the network based on network name only') do
-      finder = compute.send(:choose_finder, 'other', nil)
+      finder = request.send(:choose_network_finder, 'other', nil)
       found_network = fake_networks.find { |n| finder.call(n) }
       found_network.name == 'other' && found_network.dvs_name == 'other'
     end
     test('choose the network based on network name only for non-dvs') do
-      finder = compute.send(:choose_finder, 'non-dvs', nil)
+      finder = request.send(:choose_network_finder, 'non-dvs', nil)
       found_network = fake_networks.find { |n| finder.call(n) }
       found_network.name == 'non-dvs' && found_network.class.name.to_s == 'OpenStruct'
     end


### PR DESCRIPTION
Follow up of #195 - the request encapsulation.
This is a draft how this would look like.

I have taken the create_vm command, I have put it in separate class.
Pulled all dependencies into its ancestor.
The ancestor is quite big now, what would have to be addressed.
But I believe it is still better than having the same in `Fog::Vsphere::Compute::Real` class.
After some improvements agreed upon, I will rewrite #195 on top of it.