### PR TITLE
[WIP] Deprecate VirtualDisk capacityInKB

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -243,9 +243,15 @@ module Fog
           disk.set_unit_number
           disk.set_key
 
+          size_def =  if vsphere_rev.to_f > 5.5
+                        { capacityInBytes: disk.size * 1024 }
+                      else
+                        { capacityInKB: disk.size }
+                      end
+
           payload = {
             operation: operation,
-            device: RbVmomi::VIM.VirtualDisk(
+            device: RbVmomi::VIM.VirtualDisk(size_def.merge(
               key: disk.key,
               backing: RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
                 fileName: options[:filename] || datastore,
@@ -253,9 +259,8 @@ module Fog
                 thinProvisioned: disk.thin
               ),
               controllerKey: disk.controller_key,
-              unitNumber: disk.unit_number,
-              capacityInKB: disk.size
-            )
+              unitNumber: disk.unit_number
+            ))
           }
           file_operation = options[:file_operation] || (:create if operation == :add)
           payload[:fileOperation] = file_operation if file_operation

--- a/lib/fog/vsphere/requests/compute/list_vm_volumes.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_volumes.rb
@@ -15,7 +15,8 @@ module Fog
         #    uuid: "6000C29c-a47d-4cd9-5249-c371de775f06",
         #    writeThrough: false
         #  ),
-        #  capacityInKB: 8388608,
+        #  capacityInKB: 8388608,       # rev <= 5.5
+        #  capacityInBytes: 8589934592, # rev >= 5.5
         #  controllerKey: 1000,
         #  deviceInfo: Description(
         #    dynamicProperty: [],
@@ -44,7 +45,7 @@ module Fog
                              rescue
                                (nil)
                              end),
-              size: vol.capacityInKB,
+              size: vsphere_rev.to_f > 5.5 ? vol.capacityInBytes / 1024 : vol.capacityInKB,
               name: vol.deviceInfo.label,
               key: vol.key,
               unit_number: vol.unitNumber,


### PR DESCRIPTION
Attribute capacityInKB is deprecated as stated in docs: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/6b586ed2-655c-49d9-9029-bc416323cb22/fa0b429a-a695-4c11-b7d2-2cbc284049dc/doc/vim.vm.device.VirtualDisk.html

It works fine till version 6.7, but I believe is better to be safe than sorry (and as I have already accidently found that, why not to fix it)