### PR TITLE
Fixes #203 - network lookup by its ref

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -178,7 +178,7 @@ module Fog
             )
 
           else
-            RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(deviceName: nic.network)
+            RbVmomi::VIM.VirtualEthernetCardNetworkBackingInfo(deviceName: raw_network.name)
           end
         end
 

--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -2,16 +2,16 @@ module Fog
   module Vsphere
     class Compute
       class Real
-        def get_network(name, datacenter_name)
-          network = get_raw_network(name, datacenter_name)
+        def get_network(ref_or_name, datacenter_name)
+          network = get_raw_network(ref_or_name, datacenter_name)
           raise(Fog::Vsphere::Compute::NotFound) unless network
           network_attributes(network, datacenter_name)
         end
 
         protected
 
-        def get_raw_network(name, datacenter_name, distributedswitch = nil)
-          finder = choose_finder(name, distributedswitch)
+        def get_raw_network(ref_or_name, datacenter_name, distributedswitch = nil)
+          finder = choose_finder(ref_or_name, distributedswitch)
           get_all_raw_networks(datacenter_name).find { |n| finder.call(n) }
         end
       end
@@ -23,20 +23,26 @@ module Fog
           list_container_view(datacenter_name, 'Network', :networkFolder)
         end
 
-        def choose_finder(name, distributedswitch)
+        def choose_finder(ref_or_name, distributedswitch)
           case distributedswitch
           when String
             # only the one will do
             proc do |n|
-              n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == name || n.key == name) &&
+              n._ref == ref_or_name || (
+                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name) &&
                 (n.config.distributedVirtualSwitch.name == distributedswitch)
+              )
             end
           when :dvs
             # the first distributed virtual switch will do - selected by network - gives control to vsphere
-            proc { |n| n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == name || n.key == name) }
+            proc do |n|
+              n._ref == ref_or_name || (
+                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name)
+              )
+            end
           else
             # the first matching network will do, seems like the non-distributed networks come first
-            proc { |n| (n.name == name || (n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && n.key == name)) }
+            proc { |n| n._ref == ref_or_name || n.name == ref_or_name || (n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && n.key == ref_or_name) }
           end
         end
       end

--- a/lib/fog/vsphere/requests/compute/list_networks.rb
+++ b/lib/fog/vsphere/requests/compute/list_networks.rb
@@ -31,7 +31,7 @@ module Fog
               )
             else
               map_attrs_to_hash(network, network_attribute_mapping).merge(
-                id: managed_obj_id(network.obj)
+                id: network.obj._ref
               )
             end.merge(
               datacenter: datacenter_name,

--- a/tests/requests/compute/get_network_tests.rb
+++ b/tests/requests/compute/get_network_tests.rb
@@ -23,10 +23,10 @@ Shindo.tests('Fog::Compute[:vsphere] | get_network request', ['vsphere']) do
 
   def fake_networks
     [
-      OpenStruct.new(name: 'non-dvs'),
-      make_fake_dvs(name: 'web1', dvs_name: 'dvs5', key: '4001'),
-      make_fake_dvs(name: 'web1', dvs_name: 'dvs11', key: '4001'),
-      make_fake_dvs(name: 'other', dvs_name: 'other', key: '4001')
+      OpenStruct.new(_ref: 'network-1', name: 'non-dvs'),
+      make_fake_dvs(_ref: 'network-2', name: 'web1', dvs_name: 'dvs5', key: '4001'),
+      make_fake_dvs(_ref: 'network-3', name: 'web1', dvs_name: 'dvs11', key: '4001'),
+      make_fake_dvs(_ref: 'network-4', name: 'other', dvs_name: 'other', key: '4001')
     ]
   end
 


### PR DESCRIPTION
Make the lookup by ref available, what will effectively mean, that this is going to be valid:

```ruby
network_id = compute.networks.first.id # find my desired network

compute.servers.new interfaces: [{network: network_id}]

server = compute.servers.first
server.interfaces.first.network = network_id
```

And it is really convenient to work with id.