### PR TITLE
Bugfix/replace blank ref

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -634,8 +634,8 @@ module Fog
             end
           end
           # relocate templates is not supported by fog-vsphere when vm is cloned on a storage pod
-          unless options.key?('storage_pod')
-            unless options['volumes'].blank?
+          unless options.key?('storage_pod') && !options['volumes']
+            unless options['volumes'].empty?
               relocation_spec[:disk] = relocate_template_volumes_specs(vm_mob_ref, options['volumes'], options['datacenter'])
             end
           end

--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -634,7 +634,7 @@ module Fog
             end
           end
           # relocate templates is not supported by fog-vsphere when vm is cloned on a storage pod
-          unless options.key?('storage_pod') && !options['volumes']
+          unless options.key?('storage_pod') || !options['volumes']
             unless options['volumes'].empty?
               relocation_spec[:disk] = relocate_template_volumes_specs(vm_mob_ref, options['volumes'], options['datacenter'])
             end


### PR DESCRIPTION
the method blank? does not exist outside the rails world and throws errors. Changed it to make sure options['volumes'] is not nil and not an empty array