### PR TITLE
Save cpu and memory HotAdd enabled from server model

### DIFF
--- a/lib/fog/vsphere/requests/compute/update_vm.rb
+++ b/lib/fog/vsphere/requests/compute/update_vm.rb
@@ -20,6 +20,10 @@ module Fog
           # Memory
           spec[:memoryMB] = attributes[:memory_mb]
 
+          # HotAdd
+          spec[:cpuHotAddEnabled] = attributes[:cpuHotAddEnabled]
+          spec[:memoryHotAddEnabled] = attributes[:memoryHotAddEnabled]
+
           # Volumes
           device_change.concat(update_vm_volumes_specs(vm_mob_ref, server.volumes))
 


### PR DESCRIPTION
send cpuHotAddEnabled and memoryHotAddEnabled to ReconfigVM_Task spec, so it can be changed in server model