### PR TITLE
Fixes #237 - load simple clusters

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -276,7 +276,7 @@ module Fog
                     when :datacenter
                       RbVmomi::VIM::Datacenter
                     when :cluster
-                      RbVmomi::VIM::ClusterComputeResource
+                      RbVmomi::VIM::ComputeResource
                     when :host
                       RbVmomi::VIM::HostSystem
                     else


### PR DESCRIPTION
Simple clusters are `RbVmomi::VIM::ComputeResource` not `RbVmomi::VIM::ClusterComputeResource`