### PR TITLE
iso upload: correctly check if upload directory exists

### DIFF
--- a/lib/fog/vsphere/requests/compute/upload_iso.rb
+++ b/lib/fog/vsphere/requests/compute/upload_iso.rb
@@ -21,7 +21,7 @@ module Fog
           datastore = get_raw_datastore(options['datastore'], options['datacenter'])
           datacenter = get_raw_datacenter(options['datacenter'])
           filename = options['filename'] || File.basename(options['local_path'])
-          unless datastore.exists? options['upload_directory'] + '/'
+          unless datastore.exists?(options['upload_directory'])
             connection.serviceContent.fileManager.MakeDirectory name: "[#{options['datastore']}] #{options['upload_directory']}",
                                                                 datacenter: datacenter,
                                                                 createParentDirectories: false


### PR DESCRIPTION
See https://community.theforeman.org/t/vmware-bootdisk-provisioning-will-fail-with-failed-to-upload-iso-image-for-instance/16938/4.