### PR TITLE
fixes earlier nsx-t patches

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -29,7 +29,7 @@ module Fog
         # unitNumber: 7,
         #
         def list_vm_interfaces(vm_id, datacenter = nil)
-          get_raw_interfaces(vm_id, datacenter).map { |nic| raw_to_hash nic }
+          get_raw_interfaces(vm_id, datacenter).map { |nic| raw_to_hash(nic, datacenter) }
         end
 
         def get_vm_interface(vm_id, options = {})
@@ -61,7 +61,7 @@ module Fog
 
         private
 
-        def raw_to_hash(nic, datacenter = nil)
+        def raw_to_hash(nic, datacenter)
           if nic.backing.respond_to?(:network)
             network = nic.backing.network.name
           elsif nic.backing.respond_to?(:port)

--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -61,7 +61,7 @@ module Fog
 
         private
 
-        def raw_to_hash(nic, datacenter)
+        def raw_to_hash(nic, datacenter = nil)
           if nic.backing.respond_to?(:network)
             network = nic.backing.network.name
           elsif nic.backing.respond_to?(:port)


### PR DESCRIPTION
@timogoebel with this small fix the nsx-t network selection works again on the lastest commit on master of fog-vsphere making the earlier nsx-t patches active on the latest codebase
@ezr-ondrej if all is approved, I would appreciate a new package release and also a backport to the rpm repo of 1.24 if possible :)

thx all