### PR TITLE
Add ability to create update and delete Resource Pools #253

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -71,6 +71,9 @@ module Fog
       request :get_cluster
       request :list_resource_pools
       request :get_resource_pool
+      request :create_resource_pool
+      request :update_resource_pool
+      request :destroy_resource_pool
       request :list_networks
       request :get_network
       request :list_datastores

--- a/lib/fog/vsphere/requests/compute/create_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/create_resource_pool.rb
@@ -1,0 +1,49 @@
+module Fog
+  module Vsphere
+    class Compute
+      class Real
+        def create_resource_pool(attributes = {})
+          cluster = get_raw_cluster(attributes[:cluster], attributes[:datacenter])
+
+          root_resource_pool = if attributes[:root_resource_pool_name]
+                                 cluster.resourcePool.find attributes[:root_resource_pool_name]
+                               else
+                                 cluster.resourcePool
+                               end
+
+          root_resource_pool.CreateResourcePool(
+            name: attributes[:name],
+            spec: get_resource_pool_spec(attributes)
+          )
+
+          get_resource_pool(attributes[:name], attributes[:cluster], attributes[:datacenter])
+        end
+
+        private
+
+        def get_resource_pool_spec(attributes = {})
+          RbVmomi::VIM.ResourceConfigSpec(
+            cpuAllocation: get_resource_pool_allocation_spec(attributes.fetch(:cpu, {})),
+            memoryAllocation: get_resource_pool_allocation_spec(attributes.fetch(:memory, {}))
+          )
+        end
+
+        def get_resource_pool_allocation_spec(attributes = {})
+          RbVmomi::VIM.ResourceAllocationInfo(
+            reservation: attributes.fetch(:reservation, 0),
+            limit: attributes.fetch(:limit, -1),
+            expandableReservation: attributes.fetch(:expandable_reservation, false),
+            shares: RbVmomi::VIM.SharesInfo(
+              level: RbVmomi::VIM.SharesLevel(attributes.fetch(:shares_level, 'normal')),
+              shares: attributes.fetch(:shares, 0)
+            )
+          )
+        end
+      end
+
+      class Mock
+        def create_resource_pool(attributes = {}); end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/destroy_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/destroy_resource_pool.rb
@@ -1,0 +1,15 @@
+module Fog
+  module Vsphere
+    class Compute
+      class Real
+        def destroy_resource_pool(attributes = {})
+          get_raw_resource_pool_by_ref(attributes).Destroy_Task().wait_for_completion
+        end
+      end
+
+      class Mock
+        def destroy_resource_pool(attributes = {}); end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/update_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/update_resource_pool.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Vsphere
+    class Compute
+      class Real
+        def update_resource_pool(attributes = {})
+          raw_resource_pool = get_raw_resource_pool_by_ref(attributes)
+
+          raw_resource_pool.UpdateConfig(
+            name: attributes[:name],
+            config: get_resource_pool_spec(attributes)
+          )
+
+          get_resource_pool(attributes[:name], attributes[:cluster], attributes[:datacenter])
+        end
+
+        private
+
+        def get_raw_resource_pool_by_ref(attributes = {})
+          dc = find_raw_datacenter(attributes[:datacenter])
+          cluster = dc.find_compute_resource(attributes[:cluster])
+
+          list_raw_resource_pools(cluster).detect { |rp| rp._ref == attributes[:ref] }
+        end
+      end
+
+      class Mock
+        def update_resource_pool(attributes = {}); end
+      end
+    end
+  end
+end


### PR DESCRIPTION
 - I've added posibility manage resource pools(create/update/delete).
 - I've faced with some problems with tests that is why I don't add any one :disappointed: but I promise to add when figure out these problems.

Create
```
compute.create_resource_pool(
  datacenter: 'datacenter_name', 
  cluster: 'cluster_name', 
  name: 'resource_pool_name', 
  cpu: {reservation: '2000'},
  memory: {reservation: '512'}
)
```
Update
```
compute.update_resource_pool(
  datacenter: 'datacenter_name', 
  cluster: 'cluster_name', 
  name: 'new_resource_pool_name', 
  cpu: {reservation: '3000'},
  memory: {reservation: '1024'},
  ref: 'resource_pool_id'
)
```
Delete
```
compute.destroy_resource_pool(
  datacenter: 'datacenter_name', 
  cluster: 'cluster_name', 
  ref: 'resource_pool_id'
)
```