### PR TITLE
list_resource_pools returns incorrect resource pool name #256

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_resource_pools.rb
+++ b/lib/fog/vsphere/requests/compute/list_resource_pools.rb
@@ -36,8 +36,8 @@ module Fog
         end
 
         def resource_pool_attributes(resource_pool, cluster, datacenter)
-          name = folder_path(resource_pool).gsub(/^.*Resources(\/|)/, '')
-          name = 'Resources' if name.empty?
+          folder_path(resource_pool) =~ /(?<=Resources\/)(.+)/
+          name = Regexp.last_match(1) || 'Resources'
           {
             id: managed_obj_id(resource_pool),
             name: name,


### PR DESCRIPTION
When some resource pool('ParentResourcePool') has nested resource pool('Resources') we get this child resource pool with name 'Resources' without path of parent resource pool('Resources' instead of 'ParentResourcePool/Resources').
