### PR TITLE
Fix resource pool creation with '/' in name #261

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/create_resource_pool.rb
@@ -6,17 +6,19 @@ module Fog
           cluster = get_raw_cluster(attributes[:cluster], attributes[:datacenter])
 
           root_resource_pool = if attributes[:root_resource_pool_name]
-                                 cluster.resourcePool.find attributes[:root_resource_pool_name]
+                                 cluster.resourcePool.find attributes[:root_resource_pool_name].gsub('/', '%2f')
                                else
                                  cluster.resourcePool
                                end
 
-          root_resource_pool.CreateResourcePool(
+          raise ArgumentError, 'Root resource pool could not be found' if root_resource_pool.nil?
+
+          resource_pool = root_resource_pool.CreateResourcePool(
             name: attributes[:name],
             spec: get_resource_pool_spec(attributes)
           )
 
-          get_resource_pool(attributes[:name], attributes[:cluster], attributes[:datacenter])
+          resource_pool_attributes(resource_pool, attributes[:cluster], attributes[:datacenter])
         end
 
         private

--- a/lib/fog/vsphere/requests/compute/update_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/update_resource_pool.rb
@@ -10,7 +10,7 @@ module Fog
             config: get_resource_pool_spec(attributes)
           )
 
-          get_resource_pool(attributes[:name], attributes[:cluster], attributes[:datacenter])
+          resource_pool_attributes(raw_resource_pool, attributes[:cluster], attributes[:datacenter])
         end
 
         private


### PR DESCRIPTION
Now we can create resource pool with '/' in resource pool and root resource pool namespace.