### PR TITLE
Unify network ID attribute

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -38,7 +38,7 @@ module Fog
             # only the one will do
             proc do |n|
               n._ref == ref_or_name || (
-                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name) &&
+                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name) &&
                 (n.config.distributedVirtualSwitch.name == distributedswitch)
               )
             end
@@ -46,12 +46,12 @@ module Fog
             # the first distributed virtual switch will do - selected by network - gives control to vsphere
             proc do |n|
               n._ref == ref_or_name || (
-                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name)
+                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name)
               )
             end
           else
             # the first matching network will do, seems like the non-distributed networks come first
-            proc { |n| n._ref == ref_or_name || n.name == ref_or_name || (n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && n.key == ref_or_name) }
+            proc { |n| n._ref == ref_or_name || n.name == ref_or_name }
           end
         end
       end

--- a/lib/fog/vsphere/requests/compute/list_networks.rb
+++ b/lib/fog/vsphere/requests/compute/list_networks.rb
@@ -30,17 +30,15 @@ module Fog
                 virtualswitch: dvswitches[network['config.distributedVirtualSwitch']._ref]
               )
             elsif network.obj.is_a?(RbVmomi::VIM::OpaqueNetwork)
-              map_attrs_to_hash(network, network_dvportgroup_attribute_mapping).merge(
-                id: network.obj._ref,
+              map_attrs_to_hash(network, network_attribute_mapping).merge(
                 opaqueNetworkId: network.obj.summary.opaqueNetworkId
               )
             else
-              map_attrs_to_hash(network, network_attribute_mapping).merge(
-                id: network.obj._ref
-              )
+              map_attrs_to_hash(network, network_attribute_mapping)
             end.merge(
-              datacenter: datacenter_name,
-              _ref: network.obj._ref
+              _ref: network.obj._ref,
+              id: managed_obj_id(network.obj),
+              datacenter: datacenter_name
             )
           end.compact
         end
@@ -56,7 +54,7 @@ module Fog
 
         def network_dvportgroup_attribute_mapping
           network_attribute_mapping.merge(
-            id: 'config.key'
+            dvp_uuid: 'config.key'
           )
         end
 


### PR DESCRIPTION
Use `_ref` as ID for all kinds of networks.

See https://community.theforeman.org/t/could-not-match-network-interface-vmware-again/20862 for the detailed problem description.