### PR TITLE
Expose _ref from Compute::Network #265

### DIFF
--- a/lib/fog/vsphere/models/compute/network.rb
+++ b/lib/fog/vsphere/models/compute/network.rb
@@ -9,6 +9,7 @@ module Fog
         attribute :accessible # reachable by at least one hypervisor
         attribute :virtualswitch
         attribute :vlanid
+        attribute :_ref
 
         def to_s
           name


### PR DESCRIPTION
The get_network function in lib/fog/vsphere/requests/compute/get_network.rb
takes a name or _ref attribute.  This commit expose that _reg attribute
(already retrieved via previous vsphere call) so that clients of
fog-vsphere can look up network objects via the globally unique _ref
attribute instead of the non-unique Name attribute.

Additionally, this enables fixing a bug in clients where the id attribute
is incorrectly substituted for _ref, retrieving an incorrect object in
certain VSphere environments.