### PR TITLE
Remove autoload

### DIFF
--- a/lib/fog/vsphere/models/compute/clusters.rb
+++ b/lib/fog/vsphere/models/compute/clusters.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Clusters < Fog::Collection
-        autoload :Cluster, File.expand_path('../cluster', __FILE__)
-
         model Fog::Vsphere::Compute::Cluster
         attr_accessor :datacenter
 

--- a/lib/fog/vsphere/models/compute/customfields.rb
+++ b/lib/fog/vsphere/models/compute/customfields.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Customfields < Fog::Collection
-        autoload :Customfield, File.expand_path('../customfield', __FILE__)
-
         model Fog::Vsphere::Compute::Customfield
 
         attr_accessor :vm

--- a/lib/fog/vsphere/models/compute/customvalues.rb
+++ b/lib/fog/vsphere/models/compute/customvalues.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Customvalues < Fog::Collection
-        autoload :Customvalue, File.expand_path('../customvalue', __FILE__)
-
         model Fog::Vsphere::Compute::Customvalue
 
         attr_accessor :vm

--- a/lib/fog/vsphere/models/compute/datacenters.rb
+++ b/lib/fog/vsphere/models/compute/datacenters.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Datacenters < Fog::Collection
-        autoload :Datacenter, File.expand_path('../datacenter', __FILE__)
-
         model Fog::Vsphere::Compute::Datacenter
 
         def all(filters = {})

--- a/lib/fog/vsphere/models/compute/datastores.rb
+++ b/lib/fog/vsphere/models/compute/datastores.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Datastores < Fog::Collection
-        autoload :Datastore, File.expand_path('../datastore', __FILE__)
-
         model Fog::Vsphere::Compute::Datastore
         attr_accessor :datacenter, :cluster
 

--- a/lib/fog/vsphere/models/compute/folders.rb
+++ b/lib/fog/vsphere/models/compute/folders.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Folders < Fog::Collection
-        autoload :Folder, File.expand_path('../folder', __FILE__)
-
         model Fog::Vsphere::Compute::Folder
         attr_accessor :datacenter, :type, :path
 

--- a/lib/fog/vsphere/models/compute/interfaces.rb
+++ b/lib/fog/vsphere/models/compute/interfaces.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Interfaces < Fog::Collection
-        autoload :Interface, File.expand_path('../interface', __FILE__)
-
         model Fog::Vsphere::Compute::Interface
 
         attribute :server_id

--- a/lib/fog/vsphere/models/compute/interfacetypes.rb
+++ b/lib/fog/vsphere/models/compute/interfacetypes.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Interfacetypes < Fog::Collection
-        autoload :Interfacetype, File.expand_path('../interfacetype', __FILE__)
-
         model Fog::Vsphere::Compute::Interfacetype
         attr_accessor :datacenter
         attr_accessor :servertype

--- a/lib/fog/vsphere/models/compute/networks.rb
+++ b/lib/fog/vsphere/models/compute/networks.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Networks < Fog::Collection
-        autoload :Network, File.expand_path('../network', __FILE__)
-
         model Fog::Vsphere::Compute::Network
         attr_accessor :datacenter, :cluster
 

--- a/lib/fog/vsphere/models/compute/resource_pools.rb
+++ b/lib/fog/vsphere/models/compute/resource_pools.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class ResourcePools < Fog::Collection
-        autoload :ResourcePool, File.expand_path('../resource_pool', __FILE__)
-
         model Fog::Vsphere::Compute::ResourcePool
         attr_accessor :datacenter, :cluster
 

--- a/lib/fog/vsphere/models/compute/rules.rb
+++ b/lib/fog/vsphere/models/compute/rules.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Rules < Fog::Collection
-        autoload :Rule, File.expand_path('../rule', __FILE__)
-
         model Fog::Vsphere::Compute::Rule
         attribute :datacenter
         attribute :cluster

--- a/lib/fog/vsphere/models/compute/servers.rb
+++ b/lib/fog/vsphere/models/compute/servers.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Servers < Fog::Collection
-        autoload :Server, File.expand_path('../server', __FILE__)
-
         model Fog::Vsphere::Compute::Server
         attr_accessor :datacenter
         attr_accessor :network

--- a/lib/fog/vsphere/models/compute/servertypes.rb
+++ b/lib/fog/vsphere/models/compute/servertypes.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Servertypes < Fog::Collection
-        autoload :Servertype, File.expand_path('../servertype', __FILE__)
-
         model Fog::Vsphere::Compute::Servertype
         attr_accessor :datacenter, :id, :fullname
 

--- a/lib/fog/vsphere/models/compute/templates.rb
+++ b/lib/fog/vsphere/models/compute/templates.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Templates < Fog::Collection
-        autoload :Template, File.expand_path('../template', __FILE__)
-
         model Fog::Vsphere::Compute::Template
 
         def all(filters = {})

--- a/lib/fog/vsphere/models/compute/tickets.rb
+++ b/lib/fog/vsphere/models/compute/tickets.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Tickets < Fog::Collection
-        autoload :Ticket, File.expand_path('../ticket', __FILE__)
-
         model Fog::Vsphere::Compute::Ticket
 
         attr_accessor :server

--- a/lib/fog/vsphere/models/compute/volumes.rb
+++ b/lib/fog/vsphere/models/compute/volumes.rb
@@ -2,8 +2,6 @@ module Fog
   module Vsphere
     class Compute
       class Volumes < Fog::Collection
-        autoload :Volume, File.expand_path('../volume', __FILE__)
-
         attribute :server_id
 
         model Fog::Vsphere::Compute::Volume


### PR DESCRIPTION
autoload is wrongly namespaced for all the models, I think it confuses Rails and causes weird issues.
Issue is described here: https://community.theforeman.org/t/foreman-1-20-2-vmware-sporadic-http-500-when-querying-api-compute-resources-api/13907

@timogoebel don't you know why those `autoload`s are really there? All models are force required in the service class, so wrongly namespaced autoload is probably not what we need, right? 