### PR TITLE
Fixes #272 - ESX compute resource on vcenter 7.x fails with InvalidAr…

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -812,7 +812,7 @@ module Fog
           end
 
           new_nics.each do |interface|
-            specs << create_interface(interface, 0, :add, datacenter: datacenter)
+            specs << create_interface(interface, -rand(25000..29999), :add, datacenter: datacenter)
           end
 
           specs


### PR DESCRIPTION
…gument: A specified parameter was not correct: deviceChange[1].device.key.

The fix is to force members of new_nics (i.e. NICs that the template VM did not have but are being added to the new VM) to pass a random negative integer for the device.key value.

Originally, a key of `0` was being passed for all new NICs, so if any existing NIC (or any other new NIC) already had a key of `0` this new VM would fail to be created. vSphere before 7.0 would mostly ignore this device.key value, so setting the same value of `0` for all NICs was fine. But starting with vSphere 7.0 this value absolutely has to be unique for each NIC, even if vSphere will not use the same values.

Anyway, this "new formality" of vSphere 7.x was hurting fog-vsphere's ability to create new VMs with NICs other than the ones already present in the VM template.

The range for the index was chosen kinda arbitrarily to lie between -25,000 and -29,999. As far as I can tell, any range will do. This range has shown to function properly for at least one customer.