### PR TITLE
Fixes #272 - New NIC ID decrements from initial random int to avoid collisions

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -811,8 +811,11 @@ module Fog
             end
           end
 
+          new_nic_baseid = -rand(25000..29999)
           new_nics.each do |interface|
-            specs << create_interface(interface, -rand(25000..29999), :add, datacenter: datacenter)
+            new_nic_id = new_nic_baseid
+            new_nic_baseid-=1
+            specs << create_interface(interface, new_nic_id, :add, datacenter: datacenter)
           end
 
           specs


### PR DESCRIPTION
After some discussion at https://github.com/fog/fog-vsphere/pull/273 (merged), the code to generate a new NIC ID will now generate a new random base ID once for each new VM, deriving new NIC IDs from this base by decrementing it for each new NIC.

E.g. for a new VM the new random base ID may be -26789.
The first NIC will have NIC ID=-26790.
Second NIC will have NIC ID=-26791.
...and so on.