### PR TITLE
Fixes #35125 - Avoid unneeded "get_raw_datacenter" call

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_datacenter.rb
+++ b/lib/fog/vsphere/requests/compute/get_datacenter.rb
@@ -11,7 +11,7 @@ module Fog
         protected
 
         def find_raw_datacenter(name)
-          raw_datacenters.find { |d| d.name == name } || get_raw_datacenter(name)
+          raw_datacenters.find { |d| d.name == name || raw_getpathmo(d).join('/') == name } || get_raw_datacenter(name)
         end
 
         # @note RbVmomi takes path instead of name as argument to find datacenter


### PR DESCRIPTION
Use both name and path to match datacenter from the local cache
which will avoid fetching from Vcenter again.