### PR TITLE
Revert "Unify network ID attribute"

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -38,7 +38,7 @@ module Fog
             # only the one will do
             proc do |n|
               n._ref == ref_or_name || (
-                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name) &&
+                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name) &&
                 (n.config.distributedVirtualSwitch.name == distributedswitch)
               )
             end
@@ -46,12 +46,12 @@ module Fog
             # the first distributed virtual switch will do - selected by network - gives control to vsphere
             proc do |n|
               n._ref == ref_or_name || (
-                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name)
+                n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && (n.name == ref_or_name || n.key == ref_or_name)
               )
             end
           else
             # the first matching network will do, seems like the non-distributed networks come first
-            proc { |n| n._ref == ref_or_name || n.name == ref_or_name }
+            proc { |n| n._ref == ref_or_name || n.name == ref_or_name || (n.is_a?(RbVmomi::VIM::DistributedVirtualPortgroup) && n.key == ref_or_name) }
           end
         end
       end

--- a/lib/fog/vsphere/requests/compute/list_networks.rb
+++ b/lib/fog/vsphere/requests/compute/list_networks.rb
@@ -30,15 +30,17 @@ module Fog
                 virtualswitch: dvswitches[network['config.distributedVirtualSwitch']._ref]
               )
             elsif network.obj.is_a?(RbVmomi::VIM::OpaqueNetwork)
-              map_attrs_to_hash(network, network_attribute_mapping).merge(
+              map_attrs_to_hash(network, network_dvportgroup_attribute_mapping).merge(
+                id: network.obj._ref,
                 opaqueNetworkId: network.obj.summary.opaqueNetworkId
               )
             else
-              map_attrs_to_hash(network, network_attribute_mapping)
+              map_attrs_to_hash(network, network_attribute_mapping).merge(
+                id: network.obj._ref
+              )
             end.merge(
-              _ref: network.obj._ref,
-              id: managed_obj_id(network.obj),
-              datacenter: datacenter_name
+              datacenter: datacenter_name,
+              _ref: network.obj._ref
             )
           end.compact
         end
@@ -54,7 +56,7 @@ module Fog
 
         def network_dvportgroup_attribute_mapping
           network_attribute_mapping.merge(
-            dvp_uuid: 'config.key'
+            id: 'config.key'
           )
         end
 


### PR DESCRIPTION
## vCenter 6

#### Able to add DC to Foreman - Pass
#### List VMS - Pass

RHEL 7 - Pass
RHEL 8 - Pass
RHEL 9 - Pass

### Image:

#### Able to build a VM with Image based prov - Pass

### PXE:

#### Able to build a VM with PXE - Pass

### Bootdisk:

#### Able to build a VM with Bootdisk - Pass

### Disks:

#### Normal VM creation with single HDD on Local Datastore - Pass

#### Normal VM creation with added HDD on Local Datastore - Pass

#### Normal VM creation with single HDD on Storage Pod - Pass

#### Normal VM creation with added HDD on Storage Pod - Pass

### Network:

#### Normal VM creation with NIC in portgroup on Standard Switch - Pass

#### Normal VM creation with NIC in port group on Distributed Switch with VLAN - Pass

#### Normal VM creation with additional NIC - Pass

## vCenter 7

#### Able to add DC to Foreman - Pass
#### List VMS - Pass

RHEL 7 - Pass
RHEL 8 - Pass
RHEL 9 - Pass


### Image:

#### Able to build a VM with Image based prov - Pass

### PXE:

#### Able to build a VM with PXE - Pass

### Bootdisk:

#### Able to build a VM with Bootdisk - Pass

### Disks:

#### Normal VM creation with single HDD on Local Datastore - Pass

#### Normal VM creation with added HDD on Local Datastore - Pass

#### Normal VM creation with single HDD on Storage Pod - Pass

#### Normal VM creation with added HDD on Storage Pod - Pass

### Network:

#### Normal VM creation with NIC in portgroup on Standard Switch - Pass

#### Normal VM creation with NIC in port group on Distributed Switch with VLAN - Pass

#### Normal VM creation with additional NIC - Pass