### PR TITLE
Custom IPv6 specification should be an array - fixes #290

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -540,7 +540,7 @@ module Fog
                   else
                     custom_ipv6 = RbVmomi::VIM::CustomizationDhcpIpV6Generator.new
                   end
-                  custom_ipv6Spec = RbVmomi::VIM.CustomizationIPSettingsIpV6AddressSpec(ip: custom_ipv6)
+                  custom_ipv6Spec = RbVmomi::VIM.CustomizationIPSettingsIpV6AddressSpec(ip: [custom_ipv6])
                   custom_ipv6Spec.gateway = nic['adapter']['ipV6Spec']['gateway'] if nic['adapter']['ipV6Spec'].key?('gateway')
                   custom_adapter.ipV6Spec = custom_ipv6Spec
                 end


### PR DESCRIPTION
Fix for issue #290 which we discovered during dualstack deployments with Redhat Satellite/Foreman