### PR TITLE
Add an exception for the missing storage field

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -125,8 +125,11 @@ module Fog
         def vm_path_name(attributes)
           return '' if get_storage_pod_from_volumes(attributes)
           datastore = attributes[:volumes].first.datastore unless attributes[:volumes].empty?
-          datastore ||= 'datastore1'
-          "[#{datastore}]"
+          if datastore
+            "[#{datastore}]"
+          else
+            raise ArgumentError, 'Please mention the storage pod or the datastore'
+          end
         end
 
         def device_change(attributes)


### PR DESCRIPTION
This is a proposed solution for [#2186114](https://bugzilla.redhat.com/show_bug.cgi?id=2186114)
I think creating a host without mentioning the storage pod or the datastore should not be permitted. Adding validation is one way to go but achieving that is extremely difficult. Adding an exception is a much simpler approach to it.

I'm open for any other ideas to approach this problem. Please feel free to share your thoughts on this.
cc: @shimshtein 