### PR TITLE
Explicitly list files and dirs included in gemspec (test_)files

### DIFF
--- a/fog-vsphere.gemspec
+++ b/fog-vsphere.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/fog/fog-vsphere'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(tests?|spec|features)/}) }
-  spec.test_files    = spec.files.grep(%r{^tests\/})
+  spec.files = Dir['lib/**/*'] +
+               ['LICENSE.md', 'Rakefile', 'README.md', 'CHANGELOG.md', 'CONTRIBUTORS.md']
+  spec.test_files = Dir['tests/**/*']
 
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
With the catch all approach there were a lot of files included that do not need to be in the gem. I.e. Jenkinsfile, all dot files and dirs related to CI configuration, and rubocop linting ...

This causes problems when i.e. building rpm packages where all of these files need to be explicitly excluded: see https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/foreman/rubygem-fog-vsphere/rubygem-fog-vsphere.spec#L50