### PR TITLE
Fix warning on nil comparison

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -347,7 +347,7 @@ module Fog
         end
 
         def is_uuid?(id)
-          !(id =~ /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/).nil?
+          /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/.match?(id)
         end
       end
 


### PR DESCRIPTION
This uses the more efficient /regex/.match?(value) syntax that also doesn't raise any warning if id is nil.