### PR TITLE
Deal with non-strings in is_uuid?

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -347,7 +347,7 @@ module Fog
         end
 
         def is_uuid?(id)
-          /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/.match?(id)
+          id.is_a?(String) && /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/.match?(id)
         end
       end
 


### PR DESCRIPTION
In d971ad5ea1ae8945acad353a57b75561993cab2e the method was rewritten with the intention of being compatible with Ruby 3.3 where `=~` is only defined on strings.

A problem with this is that `/regex/.match?(nil)` works, but `/regex/.match?(42)` raises a `TypeError`. It would have been broken with the old code on Ruby 3.3 as well, but only raised a deprecation warning on prior versions.

Fixes: d971ad5ea1ae ("Fix warning on nil comparison")

This doesn't implement tests because there is no testing infrastructure at all, but given it led to a regression in Foreman that would be a good idea to do.