### PR TITLE
Correct minitest loading in tests helper

### DIFF
--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -1,6 +1,5 @@
-require 'mocha/api'
-Shindo::Tests.send(:include, Mocha::API)
-
 require 'minitest/autorun'
+require 'mocha/minitest'
+Shindo::Tests.send(:include, Mocha::API)
 
 require File.expand_path('../../lib/fog/vsphere', __FILE__)

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,3 +1,4 @@
+require 'minitest'
 require 'mocha/minitest'
 require 'vcr'
 require 'webmock/minitest'


### PR DESCRIPTION
minitest must be loaded before mocha. Modern minitest also prefers explicit choosing of the test library instead of autodetection.