### PR TITLE
Do not add :efiSecureBootEnabled bootOption unless it's true

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -188,6 +188,9 @@ module Fog
           virtual_machine_config_spec.firmware = options['firmware'] if options.key?('firmware')
           virtual_machine_config_spec.annotation = options['annotation'] if options.key?('annotation')
           virtual_machine_config_spec.extraConfig = extra_config(extra_config: options['extraConfig']) if options.key?('extraConfig')
+
+          boot_options = {}
+
           if @vsphere_rev.to_f >= 5 && options.key?('boot_order')
             boot_order = options['boot_order'].flat_map do |boot_device|
               case boot_device.to_sym
@@ -217,8 +220,13 @@ module Fog
                 RbVmomi::VIM::VirtualMachineBootOptionsBootableFloppyDevice.new
               end
             end
-            virtual_machine_config_spec.bootOptions = { bootOrder: boot_order, efiSecureBootEnabled: options["secure_boot"] || false }
+
+            boot_options[:bootOrder] = boot_order
           end
+
+          boot_options[:efiSecureBootEnabled] = options["secure_boot"] if options.key?("secure_boot")
+          virtual_machine_config_spec.bootOptions = boot_options
+
           # Options['customization_spec']
           # OLD Options still supported
           # * domain <~String> - *REQUIRED* - Sets the server's domain for customization

--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -190,7 +190,6 @@ module Fog
           virtual_machine_config_spec.extraConfig = extra_config(extra_config: options['extraConfig']) if options.key?('extraConfig')
 
           boot_options = {}
-
           if @vsphere_rev.to_f >= 5 && options.key?('boot_order')
             boot_order = options['boot_order'].flat_map do |boot_device|
               case boot_device.to_sym
@@ -225,7 +224,7 @@ module Fog
           end
 
           boot_options[:efiSecureBootEnabled] = options["secure_boot"] if options.key?("secure_boot")
-          virtual_machine_config_spec.bootOptions = boot_options
+          virtual_machine_config_spec.bootOptions = boot_options if boot_options.any?
 
           # Options['customization_spec']
           # OLD Options still supported

--- a/tests/models/compute/server_tests.rb
+++ b/tests/models/compute/server_tests.rb
@@ -1,6 +1,8 @@
 Shindo.tests('Fog::Compute[:vsphere] | server model', ['vsphere']) do
   servers = Fog::Compute[:vsphere].servers
-  server = servers.last
+  # Stable mock fixture — avoid servers.last, which after vm_clone/vm_power_off request tests can be a
+  # newly-added clone inheriting poweredOff from its template (order-dependent failure on CI).
+  server = servers.get('5029c440-85ee-c2a1-e9dd-b63e39364603')
 
   tests('The server model should') do
     tests('have the action') do


### PR DESCRIPTION
With this new behavior, the BIOS host won't have the `efiSecureBootEnabled: false` in the boot_options.

Fix suggestion from the community post: https://community.theforeman.org/t/46182

Co-Authored-By: @orelops95